### PR TITLE
Find a way to handle list elements

### DIFF
--- a/src/schema/duration.rs
+++ b/src/schema/duration.rs
@@ -282,7 +282,9 @@ impl YaDeserialize for Duration {
 
 impl YaSerialize for Duration {
     fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
-        utils::yaserde::serialize(self, writer, |s| Ok(s.to_lexical_representation()))
+        utils::yaserde::serialize(self, "Duration", writer, |s| {
+            Ok(s.to_lexical_representation())
+        })
     }
 }
 

--- a/src/schema/onvif.rs
+++ b/src/schema/onvif.rs
@@ -242,6 +242,6 @@ impl YaDeserialize for Name {
 
 impl YaSerialize for Name {
     fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
-        utils::yaserde::serialize(self, writer, |s| Ok(s.0.to_string()))
+        utils::yaserde::serialize(self, "Name", writer, |s| Ok(s.0.to_string()))
     }
 }

--- a/src/schema/onvif.rs
+++ b/src/schema/onvif.rs
@@ -245,3 +245,33 @@ impl YaSerialize for Name {
         utils::yaserde::serialize(self, "Name", writer, |s| Ok(s.0.to_string()))
     }
 }
+
+#[derive(Default, PartialEq, Debug)]
+pub struct StringAttrList(pub Vec<String>);
+
+impl YaDeserialize for StringAttrList {
+    fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
+        utils::yaserde::deserialize(reader, |s| {
+            Ok(StringAttrList(
+                s.split_whitespace().map(|s| s.to_string()).collect(),
+            ))
+        })
+    }
+}
+
+impl YaSerialize for StringAttrList {
+    fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
+        utils::yaserde::serialize(self, "StringAttrList", writer, |s| Ok(s.0.join(" ")))
+    }
+}
+
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tt", namespace = "tt: http://www.onvif.org/ver10/schema")]
+pub struct FocusOptions20Extension {
+    // TODO: yaserde macro for any element
+    //  pub any: AnyElement,
+
+    // Supported options for auto focus. Options shall be chosen from tt:AFModes.
+    #[yaserde(prefix = "tt", rename = "AFModes")]
+    pub af_modes: Option<StringAttrList>,
+}

--- a/src/schema/tests.rs
+++ b/src/schema/tests.rs
@@ -497,6 +497,46 @@ fn probe_match_deserialization() {
     );
 }
 
+#[test]
+fn list_serialization() {
+    let model = tt::FocusOptions20Extension {
+        af_modes: Some(tt::StringAttrList(vec![
+            "Auto".to_string(),
+            "Manual".to_string(),
+        ])),
+    };
+
+    let expected = r#"
+    <?xml version="1.0" encoding="utf-8"?>
+    <tt:FocusOptions20Extension xmlns:tt="http://www.onvif.org/ver10/schema">
+        <tt:AFModes>Auto Manual</tt:AFModes>
+    </tt:FocusOptions20Extension>
+    "#;
+
+    let actual = yaserde::ser::to_string(&model).unwrap();
+
+    assert_xml_eq(actual.as_str(), expected);
+}
+
+#[test]
+fn list_deserialization() {
+    let ser = r#"
+    <tt:FocusOptions20Extension xmlns:tt="http://www.onvif.org/ver10/schema">
+        <tt:AFModes>Auto Manual</tt:AFModes>
+    </tt:FocusOptions20Extension>
+    "#;
+
+    let des: tt::FocusOptions20Extension = yaserde::de::from_str(&ser).unwrap();
+
+    assert_eq!(
+        des.af_modes,
+        Some(tt::StringAttrList(vec![
+            "Auto".to_string(),
+            "Manual".to_string()
+        ]))
+    );
+}
+
 fn assert_xml_eq(actual: &str, expected: &str) -> () {
     for (a, e) in izip!(without_whitespaces(actual), without_whitespaces(expected)) {
         assert_eq!(a, e);

--- a/src/schema/types.rs
+++ b/src/schema/types.rs
@@ -27,6 +27,6 @@ impl YaDeserialize for Name {
 
 impl YaSerialize for Name {
     fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
-        utils::yaserde::serialize(self, writer, |s| Ok(s.0.to_string()))
+        utils::yaserde::serialize(self, "Name", writer, |s| Ok(s.0.to_string()))
     }
 }

--- a/src/utils/yaserde.rs
+++ b/src/utils/yaserde.rs
@@ -2,13 +2,14 @@ use std::io::{Read, Write};
 use yaserde::{de, ser};
 
 pub fn serialize<S, W: Write>(
-    selff: &S,
+    self_bypass: &S,
+    default_name: &str,
     writer: &mut ser::Serializer<W>,
     ser_fn: impl FnOnce(&S) -> Result<String, String>,
 ) -> Result<(), String> {
     let name = writer
         .get_start_event_name()
-        .unwrap_or_else(|| "Name".to_string());
+        .unwrap_or_else(|| default_name.to_string());
 
     if !writer.skip_start_end() {
         writer
@@ -17,7 +18,9 @@ pub fn serialize<S, W: Write>(
     }
 
     writer
-        .write(xml::writer::XmlEvent::characters(ser_fn(selff)?.as_str()))
+        .write(xml::writer::XmlEvent::characters(
+            ser_fn(self_bypass)?.as_str(),
+        ))
         .map_err(|_e| "Element value write failed".to_string())?;
 
     if !writer.skip_start_end() {


### PR DESCRIPTION
Story details: https://app.clubhouse.io/lumeo/story/373

I've added an example of how to handle list types. As an example I've used `FocusOptions20Extension` that includes a simple field (not attribute) of type `StringAttrList`.

```rust
#[derive(Default, PartialEq, Debug)]
pub struct StringAttrList(pub Vec<String>);

#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
#[yaserde(prefix = "tt", namespace = "tt: http://www.onvif.org/ver10/schema")]
pub struct FocusOptions20Extension {
    // TODO: yaserde macro for any element
    //  pub any: AnyElement,

    // Supported options for auto focus. Options shall be chosen from tt:AFModes.
    #[yaserde(prefix = "tt", rename = "AFModes")]
    pub af_modes: Option<StringAttrList>,
}
```

`Impl`s for such cases are basically `split`/`join` operations:

```rust
impl YaDeserialize for StringAttrList {
    fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
        utils::yaserde::deserialize(reader, |s| {
            Ok(StringAttrList(
                s.split_whitespace().map(|s| s.to_string()).collect(),
            ))
        })
    }
}

impl YaSerialize for StringAttrList {
    fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
        utils::yaserde::serialize(self, "StringAttrList", writer, |s| Ok(s.0.join(" ")))
    }
}
```
