### PR TITLE
Generate code for custom (de)serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ futures = "0.3.4"
 async-std = { version = "1.5.0", features = ["unstable"] }
 async-trait ="0.1.24"
 tokio = { version = "0.2.11", features = ["full"] }
+macro-utils = { path = "macro-utils" }

--- a/macro-utils/Cargo.toml
+++ b/macro-utils/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "macro-utils"
+version = "0.1.0"
+authors = ["Chris Bruce <chris@lumeo.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = { version = "~1.0", features = ["visit", "extra-traits"] }
+proc-macro2 = "~1.0"
+quote = "~1.0"
+
+[lib]
+name = "macro_utils"
+proc-macro = true

--- a/macro-utils/Cargo.toml
+++ b/macro-utils/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = { version = "~1.0", features = ["visit", "extra-traits"] }
+syn = "~1.0"
 proc-macro2 = "~1.0"
 quote = "~1.0"
 

--- a/macro-utils/src/lib.rs
+++ b/macro-utils/src/lib.rs
@@ -1,0 +1,22 @@
+extern crate proc_macro;
+extern crate proc_macro2;
+#[macro_use]
+extern crate quote;
+extern crate syn;
+
+mod tuple;
+
+#[proc_macro_derive(UtilsTupleSerDe)]
+pub fn tuple_serde(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = syn::parse(input).unwrap();
+
+    let from_to_string = tuple::from_to_string(&ast);
+    let serde = tuple::serde(&ast);
+
+    let ts = quote! {
+        #from_to_string
+        #serde
+    };
+
+    ts.into()
+}

--- a/macro-utils/src/tuple.rs
+++ b/macro-utils/src/tuple.rs
@@ -1,0 +1,152 @@
+use proc_macro2::TokenStream;
+use quote;
+use syn::spanned::Spanned;
+
+enum Type {
+    Simple(syn::Path),
+    String(syn::Path),
+    Struct(syn::Path),
+    Vec(syn::Path, syn::Path),
+}
+
+pub fn from_to_string(ast: &syn::DeriveInput) -> TokenStream {
+    match &ast.data {
+        syn::Data::Struct(data_struct) => {
+            let struct_name = &ast.ident;
+
+            let field_path = extract_field_path(&data_struct).expect("Bad field count or type");
+
+            let ty = Type::from_path(&field_path);
+
+            let from = from_str(&ty);
+
+            let to = to_string(&ty);
+
+            quote! {
+                impl #struct_name {
+                    pub fn from_str(s: &str) -> Result<#struct_name, String> {
+                        use std::str::FromStr;
+
+                        Ok(#struct_name(#from))
+                    }
+
+                    pub fn to_string(&self) -> Result<String, String> {
+                        use itertools::Itertools;
+
+                        Ok(#to)
+                    }
+                }
+            }
+        }
+        _ => unimplemented!("Implemented only for structs"),
+    }
+}
+
+fn from_str(ty: &Type) -> TokenStream {
+    match ty {
+        Type::String(_) => quote! { s.to_string() },
+        Type::Simple(ty) => quote! { #ty::from_str(s).map_err(|e| e.to_string())? },
+        Type::Struct(ty) => quote! { #ty::from_str(s)? },
+        Type::Vec(_, subtype) => match Type::from_path(&subtype) {
+            Type::String(subtype) | Type::Struct(subtype) | Type::Simple(subtype) => quote! {
+                s.split_whitespace()
+                    .filter_map(|s| #subtype::from_str(s).ok())
+                    .collect()
+            },
+            _ => syn::Error::new(subtype.span(), "Not implemented for this subtype")
+                .to_compile_error(),
+        },
+    }
+}
+
+fn to_string(ty: &Type) -> TokenStream {
+    match ty {
+        Type::String(_) => quote! { self.0.clone() },
+        Type::Simple(_) => quote! { self.0.to_string() },
+        Type::Struct(_) => quote! { self.0.to_string()? },
+        Type::Vec(_, subtype) => match Type::from_path(&subtype) {
+            Type::Simple(_) | Type::String(_) => quote! {
+                self.0
+                    .iter()
+                    .join(" ")
+            },
+            Type::Struct(_) => quote! {
+                self.0
+                    .iter()
+                    .flat_map(|x| x.to_string().ok())
+                    .join(" ")
+            },
+            _ => syn::Error::new(subtype.span(), "Not implemented for this subtype")
+                .to_compile_error(),
+        },
+    }
+}
+
+impl Type {
+    pub fn from_path(path: &syn::Path) -> Type {
+        match path
+            .segments
+            .last()
+            .expect("Empty type")
+            .ident
+            .to_string()
+            .as_str()
+        {
+            "bool" | "i8" | "u8" | "i16" | "u16" | "i32" | "u32" | "i64" | "u64" | "f32"
+            | "f64" => Type::Simple(path.clone()),
+            "String" => Type::String(path.clone()),
+            "Vec" => Type::Vec(
+                path.clone(),
+                extract_subtype(path.segments.last().expect("Missing subtype"))
+                    .expect("Vec subtype not found")
+                    .clone(),
+            ),
+            _ => Type::Struct(path.clone()),
+        }
+    }
+}
+
+pub fn serde(ast: &syn::DeriveInput) -> TokenStream {
+    let struct_name = &ast.ident;
+    let struct_name_literal = &ast.ident.to_string();
+
+    quote! {
+        impl YaSerialize for #struct_name {
+            fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
+                utils::yaserde::serialize(self, #struct_name_literal, writer, |s| s.to_string())
+            }
+        }
+
+        impl YaDeserialize for #struct_name {
+            fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
+                utils::yaserde::deserialize(reader, |s| #struct_name::from_str(s))
+            }
+        }
+    }
+}
+
+fn extract_field_path(data_struct: &syn::DataStruct) -> Option<&syn::Path> {
+    if let syn::Fields::Unnamed(fields) = &data_struct.fields {
+        if let Some(field) = fields.unnamed.first() {
+            if let syn::Type::Path(path) = &field.ty {
+                return Some(&path.path);
+            }
+        }
+    }
+
+    None
+}
+
+fn extract_subtype(path: &syn::PathSegment) -> Option<&syn::Path> {
+    if let syn::PathArguments::AngleBracketed(args) = &path.arguments {
+        if let Some(arg) = args.args.last() {
+            if let syn::GenericArgument::Type(ty) = arg {
+                if let syn::Type::Path(path) = ty {
+                    return Some(&path.path);
+                }
+            }
+        }
+    }
+
+    None
+}

--- a/src/schema/devicemgmt.rs
+++ b/src/schema/devicemgmt.rs
@@ -89,7 +89,7 @@ pub struct GetSystemDateAndTime {}
 )]
 pub struct GetSystemDateAndTimeResponse {
     #[yaserde(prefix = "tds", rename = "SystemDateAndTime")]
-    pub system_date_and_time: tt::SystemDateAndTime,
+    pub system_date_and_time: tt::SystemDateTime,
 }
 
 //    <wsdl:operation name="GetSystemDateAndTime">

--- a/src/schema/tests.rs
+++ b/src/schema/tests.rs
@@ -19,46 +19,47 @@ impl transport::Transport for FakeTransport {
 fn basic_deserialization() {
     let response = r#"
     <?xml version="1.0" encoding="UTF-8"?>
-            <tds:GetSystemDateAndTimeResponse
-                xmlns:tt="http://www.onvif.org/ver10/schema"
-                xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
-                <tds:SystemDateAndTime>
-                    <tt:DateTimeType>NTP</tt:DateTimeType>
-                    <tt:DaylightSavings>false</tt:DaylightSavings>
-                    <tt:TimeZone>
-                        <tt:TZ>PST7PDT</tt:TZ>
-                    </tt:TimeZone>
-                    <tt:UTCDateTime>
-                        <tt:Time>
-                            <tt:Hour>16</tt:Hour>
-                            <tt:Minute>20</tt:Minute>
-                            <tt:Second>9</tt:Second>
-                        </tt:Time>
-                        <tt:Date>
-                            <tt:Year>2019</tt:Year>
-                            <tt:Month>11</tt:Month>
-                            <tt:Day>18</tt:Day>
-                        </tt:Date>
-                    </tt:UTCDateTime>
-                </tds:SystemDateAndTime>
-            </tds:GetSystemDateAndTimeResponse>
+    <tds:GetSystemDateAndTimeResponse
+        xmlns:tt="http://www.onvif.org/ver10/schema"
+        xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
+        <tds:SystemDateAndTime>
+            <tt:DateTimeType>NTP</tt:DateTimeType>
+            <tt:DaylightSavings>false</tt:DaylightSavings>
+            <tt:TimeZone>
+                <tt:TZ>PST7PDT</tt:TZ>
+            </tt:TimeZone>
+            <tt:UTCDateTime>
+                <tt:Time>
+                    <tt:Hour>16</tt:Hour>
+                    <tt:Minute>20</tt:Minute>
+                    <tt:Second>9</tt:Second>
+                </tt:Time>
+                <tt:Date>
+                    <tt:Year>2019</tt:Year>
+                    <tt:Month>11</tt:Month>
+                    <tt:Day>18</tt:Day>
+                </tt:Date>
+            </tt:UTCDateTime>
+        </tds:SystemDateAndTime>
+    </tds:GetSystemDateAndTimeResponse>
     "#;
 
     let response: devicemgmt::GetSystemDateAndTimeResponse =
         yaserde::de::from_str(&response).unwrap();
-    let system_date_and_time = response.system_date_and_time;
 
-    println!("{:#?}", system_date_and_time);
+    let de = response.system_date_and_time;
 
-    assert_eq!(system_date_and_time.date_time_type, "NTP");
-    assert_eq!(system_date_and_time.daylight_savings, false);
-    assert_eq!(system_date_and_time.time_zone.tz, "PST7PDT");
-    assert_eq!(system_date_and_time.utc_date_time.date.year, 2019);
-    assert_eq!(system_date_and_time.utc_date_time.date.month, 11);
-    assert_eq!(system_date_and_time.utc_date_time.date.day, 18);
-    assert_eq!(system_date_and_time.utc_date_time.time.hour, 16);
-    assert_eq!(system_date_and_time.utc_date_time.time.minute, 20);
-    assert_eq!(system_date_and_time.utc_date_time.time.second, 9);
+    println!("{:#?}", de);
+
+    assert_eq!(de.date_time_type, tt::SetDateTimeType::Ntp);
+    assert_eq!(de.daylight_savings, false);
+    assert_eq!(de.time_zone.unwrap().tz, "PST7PDT");
+    assert_eq!(de.utc_date_time.as_ref().unwrap().date.year, 2019);
+    assert_eq!(de.utc_date_time.as_ref().unwrap().date.month, 11);
+    assert_eq!(de.utc_date_time.as_ref().unwrap().date.day, 18);
+    assert_eq!(de.utc_date_time.as_ref().unwrap().time.hour, 16);
+    assert_eq!(de.utc_date_time.as_ref().unwrap().time.minute, 20);
+    assert_eq!(de.utc_date_time.as_ref().unwrap().time.second, 9);
 }
 
 #[test]
@@ -105,40 +106,41 @@ fn extend_base_deserialization() {
     </tt:VideoSourceConfiguration>
     "#;
 
-    let des: tt::VideoSourceConfiguration = yaserde::de::from_str(&ser).unwrap();
+    let de: tt::VideoSourceConfiguration = yaserde::de::from_str(&ser).unwrap();
 
-    assert_eq!(des.token, "V_SRC_CFG_000");
-    assert_eq!(des.name, tt::Name("V_SRC_CFG_000".to_string()));
-    assert_eq!(des.use_count, 2);
-    assert_eq!(des.source_token, "V_SRC_000");
-    assert_eq!(des.bounds.x, 0);
-    assert_eq!(des.bounds.y, 0);
-    assert_eq!(des.bounds.width, 1280);
-    assert_eq!(des.bounds.height, 720);
+    assert_eq!(de.token, tt::ReferenceToken("V_SRC_CFG_000".to_string()));
+    assert_eq!(de.name, tt::Name("V_SRC_CFG_000".to_string()));
+    assert_eq!(de.use_count, 2);
+    assert_eq!(de.source_token, tt::ReferenceToken("V_SRC_000".to_string()));
+    assert_eq!(de.bounds.x, 0);
+    assert_eq!(de.bounds.y, 0);
+    assert_eq!(de.bounds.width, 1280);
+    assert_eq!(de.bounds.height, 720);
 }
 
 #[test]
 fn extend_base_serialization() {
     let model = tt::VideoSourceConfiguration {
-        token: "123abc".to_string(),
+        token: tt::ReferenceToken("123abc".to_string()),
         name: tt::Name("MyName".to_string()),
         use_count: 2,
-        source_token: "456cde".to_string(),
+        source_token: tt::ReferenceToken("456cde".to_string()),
         bounds: tt::IntRectangle {
             x: 1,
             y: 2,
             width: 3,
             height: 4,
         },
+        ..Default::default()
     };
 
     let expected = r#"
     <?xml version="1.0" encoding="utf-8"?>
     <tt:VideoSourceConfiguration xmlns:tt="http://www.onvif.org/ver10/schema" token="123abc">
-        <tt:Name>MyName</tt:Name>
-        <tt:UseCount>2</tt:UseCount>
         <tt:SourceToken>456cde</tt:SourceToken>
         <tt:Bounds x="1" y="2" width="3" height="4" />
+        <tt:Name>MyName</tt:Name>
+        <tt:UseCount>2</tt:UseCount>
     </tt:VideoSourceConfiguration>"#;
 
     let actual = yaserde::ser::to_string(&model).unwrap();
@@ -170,7 +172,7 @@ fn choice_deserialization() {
 
     let des: tt::ColorOptions = yaserde::de::from_str(&ser).unwrap();
 
-    match des.choice {
+    match des.color_options_choice {
         tt::ColorOptionsChoice::ColorspaceRange(colors) => {
             assert_eq!(colors.len(), 2);
 
@@ -220,16 +222,14 @@ fn choice_deserialization() {
             );
             assert_eq!(colors[1].colorspace, String::from("http://my.color.space"));
         }
-        _ => panic!("Wrong variant: {:?}", des.choice),
+        _ => panic!("Wrong variant: {:?}", des.color_options_choice),
     }
-
-    assert_eq!(des.any_attribute, Some("attr_value".to_string()));
 }
 
 #[test]
 fn choice_serialization() {
     let model = tt::ColorOptions {
-        choice: tt::ColorOptionsChoice::ColorspaceRange(vec![
+        color_options_choice: tt::ColorOptionsChoice::ColorspaceRange(vec![
             tt::ColorspaceRange {
                 x: tt::FloatRange {
                     min: 0.1,
@@ -261,12 +261,11 @@ fn choice_serialization() {
                 colorspace: "http://my.color.space".to_string(),
             },
         ]),
-        any_attribute: Some("attr_value".to_string()),
     };
 
     let expected = r#"
     <?xml version="1.0" encoding="utf-8"?>
-    <tt:ColorOptions tt:any_attribute="attr_value" xmlns:tt="http://www.onvif.org/ver10/schema">
+    <tt:ColorOptions xmlns:tt="http://www.onvif.org/ver10/schema">
         <ColorspaceRange>
             <tt:X><tt:Min>0.1</tt:Min><tt:Max>0.11</tt:Max></tt:X>
             <tt:Y><tt:Min>0.2</tt:Min><tt:Max>0.22</tt:Max></tt:Y>
@@ -372,7 +371,10 @@ async fn operation_get_system_date_and_time() {
         .await
         .unwrap();
 
-    assert_eq!(resp.system_date_and_time.utc_date_time.time.second, 40);
+    assert_eq!(
+        resp.system_date_and_time.utc_date_time.unwrap().time.second,
+        40
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Story details: https://app.clubhouse.io/lumeo/story/374

I've simplified a bit requirements to generated code for tuples. Now the only needed thing for all kinds of tuples is to add a derive of `UtilsTupleSerDe`:

```rust
#[derive(Default, PartialEq, Debug, UtilsTupleSerDe)]
pub struct TopicNamespaceLocation(pub String);
```