### PR TITLE
Implemented types Integer and Decimal that wrap BigInt and BigDecimal respectively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ async-std = { version = "1.5.0", features = ["unstable"] }
 async-trait ="0.1.24"
 tokio = { version = "0.2.11", features = ["full"] }
 num-bigint = "0.2.6"
+bigdecimal = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ futures = "0.3.4"
 async-std = { version = "1.5.0", features = ["unstable"] }
 async-trait ="0.1.24"
 tokio = { version = "0.2.11", features = ["full"] }
+num-bigint = "0.2.6"

--- a/src/schema/decimal.rs
+++ b/src/schema/decimal.rs
@@ -1,0 +1,84 @@
+use crate::utils;
+use bigdecimal::BigDecimal;
+use num_bigint::ToBigInt;
+use std::io::{Read, Write};
+use std::str::FromStr;
+use yaserde::{YaDeserialize, YaSerialize};
+
+#[derive(Default, PartialEq, Debug)]
+pub struct Decimal {
+    pub value: BigDecimal,
+}
+
+impl Decimal {
+    fn from_bigdecimal(bigdecimal: BigDecimal) -> Self {
+        Decimal{value: bigdecimal}
+    }
+
+    fn to_bigdecimal(&self) -> Option<BigDecimal> {
+        Some(self.value.clone())
+    }
+}
+
+impl YaDeserialize for Decimal {
+    fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
+        utils::yaserde::deserialize(reader, |s| Ok(Decimal::from_bigdecimal(BigDecimal::from_str(s).unwrap())))
+    }
+}
+
+impl YaSerialize for Decimal {
+    fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
+        utils::yaserde::serialize(self, "Decimal", writer, |s| {
+            Ok(s.value.to_string())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::tests::assert_xml_eq;
+
+    #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+    #[yaserde(
+        prefix = "t",
+        namespace = "t: test"
+    )]
+    pub struct DecimalPair {
+        #[yaserde(prefix = "t", rename = "First")]
+        pub first: Decimal,
+
+        #[yaserde(prefix = "t", rename = "Second")]
+        pub second: Decimal,
+    }
+
+    #[test]
+    fn integer_serialize_test() {
+        let expected = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <t:DecimalPair xmlns:t="test">
+                <t:First>0.01234</t:First>
+                <t:Second>-12.34</t:Second>
+            </t:DecimalPair>
+            "#;
+        let i = DecimalPair{first: Decimal::from_bigdecimal(BigDecimal::new(1234.to_bigint().unwrap(), 5)),
+                            second: Decimal::from_bigdecimal(BigDecimal::new(-1234.to_bigint().unwrap(), 2))};
+        let actual =yaserde::ser::to_string(&i).unwrap();
+        assert_xml_eq(&actual, expected);
+    }
+
+    #[test]
+    fn integer_deserialize_test() {
+        // Value "+0.01234" is used to check optional plus sign deserialization.
+        let s = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <t:DecimalPair xmlns:t="test">
+                <t:First>+0.01234</t:First>
+                <t:Second>-12.34</t:Second>
+            </t:DecimalPair>
+            "#;
+        let i: DecimalPair = yaserde::de::from_str(&s).unwrap();
+        assert_eq!(i.first.to_bigdecimal().unwrap(), BigDecimal::new(1234.to_bigint().unwrap(), 5));
+        assert_eq!(i.second.to_bigdecimal().unwrap(), BigDecimal::new(-1234.to_bigint().unwrap(), 2));
+    }
+}

--- a/src/schema/integer.rs
+++ b/src/schema/integer.rs
@@ -1,0 +1,85 @@
+use crate::utils;
+use num_bigint::{BigInt, ToBigInt};
+use std::io::{Read, Write};
+use std::str::FromStr;
+use yaserde::{YaDeserialize, YaSerialize};
+
+#[derive(Default, PartialEq, Debug)]
+pub struct Integer {
+    pub value: BigInt,
+}
+
+impl Integer {
+    fn from_bigint(bigint: BigInt) -> Self {
+        Integer{value: bigint}
+    }
+}
+
+impl ToBigInt for Integer {
+    fn to_bigint(&self) -> Option<BigInt> {
+        Some(self.value.clone())
+    }
+}
+
+impl YaDeserialize for Integer {
+    fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
+        utils::yaserde::deserialize(reader, |s| Ok(Integer::from_bigint(BigInt::from_str(s).unwrap())))
+    }
+}
+
+impl YaSerialize for Integer {
+    fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
+        utils::yaserde::serialize(self, "Integer", writer, |s| {
+            Ok(s.value.to_str_radix(10))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::tests::assert_xml_eq;
+
+    #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+    #[yaserde(
+        prefix = "t",
+        namespace = "t: test"
+    )]
+    pub struct IntegerPair {
+        #[yaserde(prefix = "t", rename = "First")]
+        pub first: Integer,
+
+        #[yaserde(prefix = "t", rename = "Second")]
+        pub second: Integer,
+    }
+
+    #[test]
+    fn integer_serialize_test() {
+        let expected = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <t:IntegerPair xmlns:t="test">
+                <t:First>1234</t:First>
+                <t:Second>-1234</t:Second>
+            </t:IntegerPair>
+            "#;
+        let i = IntegerPair{first: Integer::from_bigint(1234.to_bigint().unwrap()),
+                            second: Integer::from_bigint(-1234.to_bigint().unwrap())};
+        let actual =yaserde::ser::to_string(&i).unwrap();
+        assert_xml_eq(&actual, expected);
+    }
+
+    #[test]
+    fn integer_deserialize_test() {
+        // Value "+1234" is used to check optional plus sign deserialization.
+        let s = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <t:IntegerPair xmlns:t="test">
+                <t:First>+1234</t:First>
+                <t:Second>-1234</t:Second>
+            </t:IntegerPair>
+            "#;
+        let i: IntegerPair = yaserde::de::from_str(&s).unwrap();
+        assert_eq!(i.first.to_bigint().unwrap(), 1234.to_bigint().unwrap());
+        assert_eq!(i.second.to_bigint().unwrap(), -1234.to_bigint().unwrap());
+    }
+}

--- a/src/schema/integer.rs
+++ b/src/schema/integer.rs
@@ -10,7 +10,7 @@ pub struct Integer {
 }
 
 impl Integer {
-    fn from_bigint(bigint: BigInt) -> Self {
+    pub fn from_bigint(bigint: BigInt) -> Self {
         Integer{value: bigint}
     }
 }
@@ -23,7 +23,11 @@ impl ToBigInt for Integer {
 
 impl YaDeserialize for Integer {
     fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
-        utils::yaserde::deserialize(reader, |s| Ok(Integer::from_bigint(BigInt::from_str(s).unwrap())))
+        utils::yaserde::deserialize(reader, |s| {
+            BigInt::from_str(s)
+                .map(Integer::from_bigint)
+                .map_err(|e| e.to_string())
+        })
     }
 }
 

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,6 +1,7 @@
 // xsd:
 pub mod common;
 pub mod duration;
+pub mod integer;
 #[allow(unused_imports)]
 pub mod metadatastream;
 pub mod onvif;

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,5 +1,6 @@
 // xsd:
 pub mod common;
+pub mod decimal;
 pub mod duration;
 pub mod integer;
 #[allow(unused_imports)]

--- a/src/schema/tests.rs
+++ b/src/schema/tests.rs
@@ -543,7 +543,7 @@ fn list_deserialization() {
     );
 }
 
-fn assert_xml_eq(actual: &str, expected: &str) -> () {
+pub fn assert_xml_eq(actual: &str, expected: &str) -> () {
     for (a, e) in izip!(without_whitespaces(actual), without_whitespaces(expected)) {
         assert_eq!(a, e);
     }


### PR DESCRIPTION
Story: https://app.clubhouse.io/lumeo/story/370/wrap-bignum-types-from-third-party-crates-to-handle-bignum-types-from-xsd