### PR TITLE
Refactor utils yaserde

### DIFF
--- a/macro-utils/src/lib.rs
+++ b/macro-utils/src/lib.rs
@@ -10,11 +10,13 @@ mod tuple;
 pub fn tuple_serde(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
-    let from_to_string = tuple::from_to_string(&ast);
+    let from_str = tuple::from_str(&ast);
+    let display = tuple::display(&ast);
     let serde = tuple::serde(&ast);
 
     let ts = quote! {
-        #from_to_string
+        #from_str
+        #display
         #serde
     };
 

--- a/src/schema/common.rs
+++ b/src/schema/common.rs
@@ -8,6 +8,7 @@
 use crate::utils;
 use macro_utils::*;
 use std::io::{Read, Write};
+use std::str::FromStr;
 use yaserde::{YaDeserialize, YaSerialize};
 
 //generated file

--- a/src/schema/onvif.rs
+++ b/src/schema/onvif.rs
@@ -20,6 +20,7 @@ use crate::schema::{b_2 as wsnt, soap_envelope as soapenv, xmlmime as xmime, xop
 use crate::utils;
 use macro_utils::*;
 use std::io::{Read, Write};
+use std::str::FromStr;
 use yaserde::{YaDeserialize, YaSerialize};
 
 //generated file

--- a/src/schema/tests.rs
+++ b/src/schema/tests.rs
@@ -493,7 +493,7 @@ fn probe_match_deserialization() {
 }
 
 #[test]
-fn list_serialization() {
+fn string_list_serialization() {
     let model = tt::FocusOptions20Extension {
         af_modes: Some(tt::StringAttrList(vec![
             "Auto".to_string(),
@@ -514,7 +514,7 @@ fn list_serialization() {
 }
 
 #[test]
-fn list_deserialization() {
+fn string_list_deserialization() {
     let ser = r#"
         <tt:FocusOptions20Extension xmlns:tt="http://www.onvif.org/ver10/schema">
             <tt:AFModes>Auto Manual</tt:AFModes>
@@ -530,4 +530,30 @@ fn list_deserialization() {
             "Manual".to_string()
         ]))
     );
+}
+
+#[test]
+fn float_list_serialization() {
+    let model = tt::FloatAttrList(vec![1.0, 2.3, 3.99]);
+
+    let expected = r#"
+        <?xml version="1.0" encoding="utf-8"?>
+        <FloatAttrList>1 2.3 3.99</FloatAttrList>
+        "#;
+
+    let actual = yaserde::ser::to_string(&model).unwrap();
+
+    assert_xml_eq(actual.as_str(), expected);
+}
+
+#[test]
+fn float_list_deserialization() {
+    let ser = r#"
+        <?xml version="1.0" encoding="utf-8"?>
+        <FloatAttrList>1 2.3 3.99</FloatAttrList>
+        "#;
+
+    let des: tt::FloatAttrList = yaserde::de::from_str(&ser).unwrap();
+
+    assert_eq!(des, tt::FloatAttrList(vec![1.0, 2.3, 3.99]));
 }

--- a/src/schema/types.rs
+++ b/src/schema/types.rs
@@ -27,6 +27,6 @@ impl YaDeserialize for Name {
 
 impl YaSerialize for Name {
     fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
-        utils::yaserde::serialize(self, "Name", writer, |s| Ok(s.0.to_string()))
+        utils::yaserde::serialize(self, "Name", writer, |s| s.0.to_string())
     }
 }

--- a/src/schema/xmlmime.rs
+++ b/src/schema/xmlmime.rs
@@ -1,6 +1,7 @@
 use crate::utils;
 use macro_utils::*;
 use std::io::{Read, Write};
+use std::str::FromStr;
 use yaserde::{YaDeserialize, YaSerialize};
 
 #[derive(Default, PartialEq, Debug, UtilsTupleSerDe)]

--- a/src/schema/xs/decimal.rs
+++ b/src/schema/xs/decimal.rs
@@ -31,7 +31,7 @@ impl YaDeserialize for Decimal {
 
 impl YaSerialize for Decimal {
     fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
-        utils::yaserde::serialize(self, "Decimal", writer, |s| Ok(s.value.to_string()))
+        utils::yaserde::serialize(self, "Decimal", writer, |s| s.value.to_string())
     }
 }
 

--- a/src/schema/xs/duration.rs
+++ b/src/schema/xs/duration.rs
@@ -282,9 +282,7 @@ impl YaDeserialize for Duration {
 
 impl YaSerialize for Duration {
     fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
-        utils::yaserde::serialize(self, "Duration", writer, |s| {
-            Ok(s.to_lexical_representation())
-        })
+        utils::yaserde::serialize(self, "Duration", writer, |s| s.to_lexical_representation())
     }
 }
 

--- a/src/schema/xs/integer.rs
+++ b/src/schema/xs/integer.rs
@@ -33,7 +33,7 @@ impl YaDeserialize for Integer {
 
 impl YaSerialize for Integer {
     fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
-        utils::yaserde::serialize(self, "Integer", writer, |s| Ok(s.value.to_str_radix(10)))
+        utils::yaserde::serialize(self, "Integer", writer, |s| s.value.to_str_radix(10))
     }
 }
 

--- a/src/utils/yaserde.rs
+++ b/src/utils/yaserde.rs
@@ -5,7 +5,7 @@ pub fn serialize<S, W: Write>(
     self_bypass: &S,
     default_name: &str,
     writer: &mut ser::Serializer<W>,
-    ser_fn: impl FnOnce(&S) -> Result<String, String>,
+    ser_fn: impl FnOnce(&S) -> String,
 ) -> Result<(), String> {
     let name = writer
         .get_start_event_name()
@@ -19,7 +19,7 @@ pub fn serialize<S, W: Write>(
 
     writer
         .write(xml::writer::XmlEvent::characters(
-            ser_fn(self_bypass)?.as_str(),
+            ser_fn(self_bypass).as_str(),
         ))
         .map_err(|_e| "Element value write failed".to_string())?;
 


### PR DESCRIPTION
Previously tuple struct to be properly (de)serialized had to have `to_string` and `from_str` methods which are non-standard. Now trait `Display` and `FromStr` are used instead. 
Also minor refactorings of `macro-utils` crate were made.