### PR TITLE
GH action to block fixup commits from merge

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [push]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Check fixup commits. Rebase w/ autosquash required if this fails.
+      uses: 13rac1/block-fixup-merge-action@v1.1.1


### PR DESCRIPTION
Basically a copy&paste of configuration recommended here:

https://github.com/marketplace/actions/block-fixup-commit-merge