### PR TITLE
Implement std::error::Error for schema::transport::Error

### DIFF
--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -12,7 +12,6 @@ yaserde_derive = { git = "https://github.com/media-io/yaserde", rev = "137af01" 
 itertools = "0.8.1"
 chrono = "0.4.10"
 async-trait ="0.1.24"
-tokio = { version = "0.2.11", features = ["full"] }
 num-bigint = "0.2.6"
 bigdecimal = "0.1.0"
 macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "f3be2b95" }
@@ -20,3 +19,4 @@ xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "f3be2b95"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
+tokio = { version = "0.2.11", features = ["full"] }

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -16,6 +16,7 @@ num-bigint = "0.2.6"
 bigdecimal = "0.1.0"
 macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "f3be2b95" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "f3be2b95" }
+thiserror = "1.0.20"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/schema/src/transport.rs
+++ b/schema/src/transport.rs
@@ -1,10 +1,14 @@
 use async_trait::async_trait;
+use thiserror::Error;
 use yaserde::{YaDeserialize, YaSerialize};
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
+    #[error("Serialization failed: {0}")]
     Serialization(String),
+    #[error("Deserialization failed: {0}")]
     Deserialization(String),
+    #[error("Transport error: {0}")]
     Transport(String),
 }
 


### PR DESCRIPTION
Work towards #52.

I originally wanted to do `soap::Error` too in this PR, but it's unclear to me how `soap_envelope::Fault` should be displayed.