### PR TITLE
Rewrite ONVIF authorization

### DIFF
--- a/onvif/examples/camera.rs
+++ b/onvif/examples/camera.rs
@@ -1,7 +1,7 @@
 use log::debug;
 use onvif::{schema, soap};
-use reqwest::Url;
 use structopt::StructOpt;
+use url::Url;
 
 #[derive(StructOpt)]
 #[structopt(name = "camera", about = "ONVIF camera control tool")]
@@ -79,7 +79,7 @@ impl Clients {
             .ok_or_else(|| "--uri must be specified.".to_string())?;
         let devicemgmt_uri = base_uri.join("onvif/device_service").unwrap();
         let mut out = Self {
-            devicemgmt: soap::client::ClientBuilder::new(devicemgmt_uri.as_str())
+            devicemgmt: soap::client::ClientBuilder::new(&devicemgmt_uri)
                 .credentials(creds.clone())
                 .build(),
             imaging: None,
@@ -100,8 +100,9 @@ impl Clients {
                     &s.x_addr, &base_uri
                 ));
             }
+            let url = Url::parse(&s.x_addr).map_err(|e| e.to_string())?;
             let svc = Some(
-                soap::client::ClientBuilder::new(&s.x_addr)
+                soap::client::ClientBuilder::new(&url)
                     .credentials(creds.clone())
                     .build(),
             );

--- a/onvif/examples/camera.rs
+++ b/onvif/examples/camera.rs
@@ -79,7 +79,9 @@ impl Clients {
             .ok_or_else(|| "--uri must be specified.".to_string())?;
         let devicemgmt_uri = base_uri.join("onvif/device_service").unwrap();
         let mut out = Self {
-            devicemgmt: soap::client::Client::new(devicemgmt_uri.as_str(), creds.clone()),
+            devicemgmt: soap::client::ClientBuilder::new(devicemgmt_uri.as_str())
+                .credentials(creds.clone())
+                .build(),
             imaging: None,
             ptz: None,
             event: None,
@@ -98,7 +100,11 @@ impl Clients {
                     &s.x_addr, &base_uri
                 ));
             }
-            let svc = Some(soap::client::Client::new(&s.x_addr, creds.clone()));
+            let svc = Some(
+                soap::client::ClientBuilder::new(&s.x_addr)
+                    .credentials(creds.clone())
+                    .build(),
+            );
             match s.namespace.as_str() {
                 "http://www.onvif.org/ver10/device/wsdl" => {
                     if s.x_addr != devicemgmt_uri.as_str() {

--- a/onvif/src/discovery/mod.rs
+++ b/onvif/src/discovery/mod.rs
@@ -12,6 +12,7 @@ use tokio::{
     net::UdpSocket,
     time::{self, Duration, Instant},
 };
+use url::Url;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -71,7 +72,7 @@ pub enum Error {
 ///     println!("Devices found: {:?}", addrs);
 /// };
 /// ```
-pub async fn discover(duration: Duration) -> Result<impl Stream<Item = String>, Error> {
+pub async fn discover(duration: Duration) -> Result<impl Stream<Item = Url>, Error> {
     let probe = build_probe();
     let probe_xml = yaserde::ser::to_string(&probe).map_err(Error::Serde)?;
 
@@ -137,9 +138,9 @@ async fn recv_string(s: &UdpSocket, timeout: Duration) -> io::Result<String> {
 async fn get_responding_addr<F, Fut>(
     envelope: probe_matches::Envelope,
     mut check_addr: F,
-) -> Option<String>
+) -> Option<Url>
 where
-    F: FnMut(String) -> Fut,
+    F: FnMut(Url) -> Fut,
     Fut: Future<Output = bool>,
 {
     let iter = envelope
@@ -148,12 +149,18 @@ where
         .probe_match
         .iter()
         .flat_map(|probe_match| probe_match.x_addrs.split_whitespace())
-        .map(|x| x.to_string());
+        .filter_map(|x| match Url::parse(x) {
+            Ok(uri) => Some(uri),
+            Err(e) => {
+                warn!("Could not parse URL '{}': {:?}", x, e);
+                None
+            }
+        });
 
     for addr in iter {
         if check_addr(addr.clone()).await {
             debug!("Responding addr: {:?}", addr);
-            return Some(addr);
+            return Some(addr.clone());
         }
     }
 
@@ -173,7 +180,7 @@ fn build_probe() -> probe::Envelope {
     }
 }
 
-async fn is_addr_responding(uri: String) -> bool {
+async fn is_addr_responding(uri: Url) -> bool {
     schema::devicemgmt::get_system_date_and_time(
         &soap::client::ClientBuilder::new(&uri).build(),
         &Default::default(),
@@ -221,12 +228,12 @@ fn test_xaddrs_extraction() {
         make_xml(bad_uuid, "http://addr_30 http://addr_31"),
     ];
 
-    async fn is_addr_responding(uri: String) -> bool {
+    async fn is_addr_responding(uri: Url) -> bool {
         let responding_addrs = vec![
-            "http://addr_10".to_string(),
-            "http://addr_21".to_string(),
-            "http://addr_22".to_string(),
-            "http://addr_30".to_string(),
+            "http://addr_10".parse().unwrap(),
+            "http://addr_21".parse().unwrap(),
+            "http://addr_22".parse().unwrap(),
+            "http://addr_30".parse().unwrap(),
         ];
 
         responding_addrs.contains(&uri)
@@ -246,14 +253,14 @@ fn test_xaddrs_extraction() {
     assert_eq!(actual.len(), 2);
 
     // OK: message UUID matches and addr responds
-    assert!(actual.contains(&"http://addr_10".to_string()));
+    assert!(actual.contains(&Url::parse("http://addr_10").unwrap()));
 
     // OK: message UUID matches and addr responds
-    assert!(actual.contains(&"http://addr_21".to_string()));
+    assert!(actual.contains(&Url::parse("http://addr_21").unwrap()));
 
     // BAD: message UUID matches and addr responds but we take only first one
-    assert!(!actual.contains(&"http://addr_22".to_string()));
+    assert!(!actual.contains(&Url::parse("http://addr_22").unwrap()));
 
     // BAD: wrong message UUID
-    assert!(!actual.contains(&"http://addr_30".to_string()));
+    assert!(!actual.contains(&Url::parse("http://addr_30").unwrap()));
 }

--- a/onvif/src/discovery/mod.rs
+++ b/onvif/src/discovery/mod.rs
@@ -1,6 +1,7 @@
 use crate::soap;
 use async_stream::stream;
 use futures_core::stream::Stream;
+use log::{debug, warn};
 use schema::ws_discovery::{probe, probe_matches};
 use std::{
     future::Future,

--- a/onvif/src/discovery/mod.rs
+++ b/onvif/src/discovery/mod.rs
@@ -175,7 +175,7 @@ fn build_probe() -> probe::Envelope {
 
 async fn is_addr_responding(uri: String) -> bool {
     schema::devicemgmt::get_system_date_and_time(
-        &soap::client::Client::new(&uri, None),
+        &soap::client::ClientBuilder::new(&uri).build(),
         &Default::default(),
     )
     .await

--- a/onvif/src/lib.rs
+++ b/onvif/src/lib.rs
@@ -1,5 +1,3 @@
-#[macro_use]
-extern crate log;
 #[cfg(test)]
 #[macro_use]
 extern crate yaserde_derive;

--- a/onvif/src/soap/client.rs
+++ b/onvif/src/soap/client.rs
@@ -21,12 +21,18 @@ impl ClientBuilder {
             config: Config {
                 uri: uri.to_string(),
                 credentials: None,
+                auth_type: AuthType::Any,
             },
         }
     }
 
     pub fn credentials(mut self, credentials: Option<Credentials>) -> Self {
         self.config.credentials = credentials;
+        self
+    }
+
+    pub fn auth_type(mut self, auth_type: AuthType) -> Self {
+        self.config.auth_type = auth_type;
         self
     }
 
@@ -46,6 +52,17 @@ impl ClientBuilder {
 struct Config {
     uri: String,
     credentials: Option<Credentials>,
+    auth_type: AuthType,
+}
+
+#[derive(Clone, Debug)]
+pub enum AuthType {
+    /// First try to authorize with Digest and in case of error try UsernameToken auth
+    Any,
+    /// Use only Digest auth
+    Digest,
+    /// Use only UsernameToken auth
+    UsernameToken,
 }
 
 #[derive(Clone)]

--- a/onvif/src/soap/client.rs
+++ b/onvif/src/soap/client.rs
@@ -4,14 +4,14 @@ use async_trait::async_trait;
 use reqwest::Url;
 use schema::transport::{Error, Transport};
 
-#[derive(Default, Debug, Clone)]
+#[derive(Clone)]
 pub struct Client {
     uri: String,
     client: reqwest::Client,
     credentials: Option<Credentials>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Clone)]
 pub struct Credentials {
     pub username: String,
     pub password: String,

--- a/schema/src/transport.rs
+++ b/schema/src/transport.rs
@@ -8,8 +8,14 @@ pub enum Error {
     Serialization(String),
     #[error("Deserialization failed: {0}")]
     Deserialization(String),
-    #[error("Transport error: {0}")]
-    Transport(String),
+    #[error("Authorization failed: {0}")]
+    Authorization(String),
+    #[error("Redirection error: {0}")]
+    Redirection(String),
+    #[error("Protocol error: {0}")]
+    Protocol(String),
+    #[error("Other: {0}")]
+    Other(String),
 }
 
 #[async_trait]


### PR DESCRIPTION
Breaking changes:
- The main change is that I've added an option to select auth type (Digest, UsernameToken, Any). For this reason `Client` public API has changed.
- Extended Transport error type so that we could match on auth errors and retry with different auth type.