### PR TITLE
schema: ws_discovery: Add missing types in Probe

### DIFF
--- a/schema/src/tests.rs
+++ b/schema/src/tests.rs
@@ -406,7 +406,9 @@ fn probe_serialization() {
                 <w:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</w:Action>
             </s:Header>
             <s:Body>
-                <d:Probe />
+                <d:Probe>
+                    <d:Types></d:Types>
+                </d:Probe>
             </s:Body>
         </s:Envelope>
         "#;

--- a/schema/src/ws_discovery.rs
+++ b/schema/src/ws_discovery.rs
@@ -4,7 +4,10 @@ pub mod probe {
         prefix = "d",
         namespace = "d: http://schemas.xmlsoap.org/ws/2005/04/discovery"
     )]
-    pub struct Probe {}
+    pub struct Probe {
+        #[yaserde(prefix = "d", rename = "Types")]
+        pub types: String,
+    }
 
     #[derive(Default, PartialEq, Debug, YaSerialize)]
     #[yaserde(


### PR DESCRIPTION
I did some tests with an intelbras DVR system,
without the types field in probes there is no reply

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>