### PR TITLE
Discovery: Extract camera name from ProbeMatch scopes

### DIFF
--- a/onvif/examples/discovery.rs
+++ b/onvif/examples/discovery.rs
@@ -13,7 +13,7 @@ async fn main() {
         .await
         .unwrap()
         .for_each_concurrent(MAX_CONCURRENT_JUMPERS, |addr| async move {
-            println!("Device found at address: {}", addr);
+            println!("Device found: {:?}", addr);
         })
         .await;
 }

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -19,6 +19,7 @@ bigdecimal = "0.2.0"
 macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "0819e36" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "0819e36" }
 thiserror = "1.0.23"
+url = "2.2.1"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"


### PR DESCRIPTION
We can extract it from scopes:
http://www.onvif.org/specs/core/ONVIF-Core-Specification-v102.pdf
"7.3.3.2 Scopes".