### PR TITLE
schema: common: Move from Movestatus enum to String

### DIFF
--- a/schema/src/common.rs
+++ b/schema/src/common.rs
@@ -108,10 +108,10 @@ impl Validate for Ptzstatus {}
 #[yaserde(prefix = "tt", namespace = "tt: http://www.onvif.org/ver10/schema")]
 pub struct PtzmoveStatus {
     #[yaserde(prefix = "tt", rename = "PanTilt")]
-    pub pan_tilt: Option<MoveStatus>,
+    pub pan_tilt: Option<String>,
 
     #[yaserde(prefix = "tt", rename = "Zoom")]
-    pub zoom: Option<MoveStatus>,
+    pub zoom: Option<String>,
 }
 
 impl Validate for PtzmoveStatus {}


### PR DESCRIPTION
yaserde enum is not working

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>