### PR TITLE
Added Auth type to camera example

### DIFF
--- a/onvif/Cargo.toml
+++ b/onvif/Cargo.toml
@@ -33,6 +33,8 @@ macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "0819e36
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "0819e36" }
 thiserror = "1.0"
 tokio = { version = "1.0.1", features = ["time"] }
+strum = "0.20"
+strum_macros = "0.20"
 
 [dev-dependencies]
 dotenv = "0.15.0"

--- a/onvif/src/soap/client.rs
+++ b/onvif/src/soap/client.rs
@@ -1,3 +1,5 @@
+extern crate strum;
+
 use crate::soap::{
     self,
     auth::{digest::Digest, username_token::UsernameToken},
@@ -10,6 +12,7 @@ use std::{
     time::Duration,
 };
 use url::Url;
+use strum_macros::EnumString;
 
 macro_rules! log {
     ($lvl:expr, $self:ident, $($arg:tt)+) => {
@@ -88,7 +91,7 @@ struct Config {
     timeout: Duration,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, EnumString)]
 pub enum AuthType {
     /// First try to authorize with Digest and in case of error try UsernameToken auth
     Any,


### PR DESCRIPTION
Hello. I had some trouble with the example. Turns out my problem was that my camera wanted UsernameToken auth type, otherwise it gave error 400. I added support for giving auth type to the example and also fixed some other smaller things I noticed in it.

- Added Auth type to camera example
- Fixed some typos in camera example
- Added error handling to some camera examples