### PR TITLE
discovery: Run `get_responding_addr` concurrently

### DIFF
--- a/onvif/Cargo.toml
+++ b/onvif/Cargo.toml
@@ -14,7 +14,6 @@ tls = ["reqwest/native-tls"]
 
 [dependencies]
 async-recursion = "0.3.1"
-async-stream = "0.3.0"
 async-trait = "0.1.41"
 base64 = "0.13.0"
 bigdecimal = "0.3.0"
@@ -27,7 +26,8 @@ reqwest = { version = "0.11.0", default-features = false }
 schema = { version = "0.1.0", path = "../schema", default-features = false, features = ["analytics", "devicemgmt", "event", "media", "ptz"] }
 sha1 = "0.6.0"
 thiserror = "1.0"
-tokio = { version = "1.0.1", features = ["time"] }
+tokio = { version = "1", features = ["sync", "time"] }
+tokio-stream = "0.1"
 tracing = "0.1.26"
 url = "2.2.0"
 uuid = { version = "0.8.1", features = ["v4"] }


### PR DESCRIPTION
Previously, we processed cameras sequentially in a loop:
```rust
loop {
    let response = recv_string().await;
    get_responding_addr(response).await;
    ...
}
```

And now, `get_responding_addr()` is called concurrently for each camera as soon as responses arrive.