### PR TITLE
Replace media2 type aliases

### DIFF
--- a/wsdl_rs/media2/src/lib.rs
+++ b/wsdl_rs/media2/src/lib.rs
@@ -424,7 +424,22 @@ pub struct GetConfiguration {
 
 impl Validate for GetConfiguration {}
 
-pub type GetVideoEncoderConfigurations = GetConfiguration;
+// pub type GetVideoEncoderConfigurations = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct  GetVideoEncoderConfigurations {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -439,7 +454,22 @@ pub struct GetVideoEncoderConfigurationsResponse {
 
 impl Validate for GetVideoEncoderConfigurationsResponse {}
 
-pub type GetVideoSourceConfigurations = GetConfiguration;
+// pub type GetVideoSourceConfigurations = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetVideoSourceConfigurations {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -454,7 +484,23 @@ pub struct GetVideoSourceConfigurationsResponse {
 
 impl Validate for GetVideoSourceConfigurationsResponse {}
 
-pub type GetAudioEncoderConfigurations = GetConfiguration;
+// pub type GetAudioEncoderConfigurations = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetAudioEncoderConfigurations {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
+
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -469,7 +515,23 @@ pub struct GetAudioEncoderConfigurationsResponse {
 
 impl Validate for GetAudioEncoderConfigurationsResponse {}
 
-pub type GetAudioSourceConfigurations = GetConfiguration;
+// pub type GetAudioSourceConfigurations = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetAudioSourceConfigurations {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
+
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -484,7 +546,22 @@ pub struct GetAudioSourceConfigurationsResponse {
 
 impl Validate for GetAudioSourceConfigurationsResponse {}
 
-pub type GetAnalyticsConfigurations = GetConfiguration;
+// pub type GetAnalyticsConfigurations = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetAnalyticsConfigurations {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -499,7 +576,23 @@ pub struct GetAnalyticsConfigurationsResponse {
 
 impl Validate for GetAnalyticsConfigurationsResponse {}
 
-pub type GetMetadataConfigurations = GetConfiguration;
+// pub type GetMetadataConfigurations = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetMetadataConfigurations {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
+
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -514,7 +607,23 @@ pub struct GetMetadataConfigurationsResponse {
 
 impl Validate for GetMetadataConfigurationsResponse {}
 
-pub type GetAudioOutputConfigurations = GetConfiguration;
+// pub type GetAudioOutputConfigurations = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetAudioOutputConfigurations {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
+
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -529,7 +638,23 @@ pub struct GetAudioOutputConfigurationsResponse {
 
 impl Validate for GetAudioOutputConfigurationsResponse {}
 
-pub type GetAudioDecoderConfigurations = GetConfiguration;
+// pub typ GetAudioDecoderConfigurations = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetAudioDecoderConfigurations {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
+
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -664,7 +789,23 @@ pub struct SetAudioDecoderConfiguration {
 impl Validate for SetAudioDecoderConfiguration {}
 
 pub type SetAudioDecoderConfigurationResponse = SetConfigurationResponse;
-pub type GetVideoSourceConfigurationOptions = GetConfiguration;
+// pub typ GetVideoSourceConfigurationOptions = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetVideoSourceConfigurationOptions {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
+
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -683,7 +824,22 @@ pub struct GetVideoSourceConfigurationOptionsResponse {
 
 impl Validate for GetVideoSourceConfigurationOptionsResponse {}
 
-pub type GetVideoEncoderConfigurationOptions = GetConfiguration;
+// pub type GetVideoEncoderConfigurationOptions = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetVideoEncoderConfigurationOptions {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -697,7 +853,22 @@ pub struct GetVideoEncoderConfigurationOptionsResponse {
 
 impl Validate for GetVideoEncoderConfigurationOptionsResponse {}
 
-pub type GetAudioSourceConfigurationOptions = GetConfiguration;
+// pub typ GetAudioSourceConfigurationOptions = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetAudioSourceConfigurationOptions {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -716,7 +887,23 @@ pub struct GetAudioSourceConfigurationOptionsResponse {
 
 impl Validate for GetAudioSourceConfigurationOptionsResponse {}
 
-pub type GetAudioEncoderConfigurationOptions = GetConfiguration;
+// pub typ GetAudioEncoderConfigurationOptions = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetAudioEncoderConfigurationOptions {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
+
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -735,7 +922,23 @@ pub struct GetAudioEncoderConfigurationOptionsResponse {
 
 impl Validate for GetAudioEncoderConfigurationOptionsResponse {}
 
-pub type GetMetadataConfigurationOptions = GetConfiguration;
+// pub typ GetMetadataConfigurationOptions = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetMetadataConfigurationOptions {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
+
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -754,7 +957,23 @@ pub struct GetMetadataConfigurationOptionsResponse {
 
 impl Validate for GetMetadataConfigurationOptionsResponse {}
 
-pub type GetAudioOutputConfigurationOptions = GetConfiguration;
+// pub typ GetAudioOutputConfigurationOptions = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetAudioOutputConfigurationOptions {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
+
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
@@ -773,7 +992,23 @@ pub struct GetAudioOutputConfigurationOptionsResponse {
 
 impl Validate for GetAudioOutputConfigurationOptionsResponse {}
 
-pub type GetAudioDecoderConfigurationOptions = GetConfiguration;
+// pub typ GetAudioDecoderConfigurationOptions = GetConfiguration;
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tr2",
+    namespace = "tr2: http://www.onvif.org/ver20/media/wsdl"
+)]
+pub struct GetAudioDecoderConfigurationOptions {
+    // Token of the requested configuration.
+    #[yaserde(prefix = "tr2", rename = "ConfigurationToken")]
+    pub configuration_token: Option<tt::ReferenceToken>,
+
+    // Contains the token of an existing media profile the configurations shall
+    // be compatible with.
+    #[yaserde(prefix = "tr2", rename = "ProfileToken")]
+    pub profile_token: Option<tt::ReferenceToken>,
+}
+
 
 #[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(


### PR DESCRIPTION
Replace media2 type aliases for GetConfiguration with copies of the struct instead because yaserde doesn't use the alias name when building the serialised data.