### PR TITLE
Altered Clients::new() URL checks to use parsed URL.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#392B11",
+        "titleBar.activeBackground": "#503D17",
+        "titleBar.activeForeground": "#FDFBF7"
+    }
+}

--- a/onvif/examples/camera.rs
+++ b/onvif/examples/camera.rs
@@ -111,7 +111,7 @@ impl Clients {
             if !url.as_str().starts_with(base_uri.as_str()) {
                 return Err(format!(
                     "Service URI {} is not within base URI {}",
-                    &s.x_addr, &base_uri
+                    url.as_str(), &base_uri
                 ));
             }
             let svc = Some(
@@ -121,10 +121,10 @@ impl Clients {
             );
             match s.namespace.as_str() {
                 "http://www.onvif.org/ver10/device/wsdl" => {
-                    if s.x_addr != devicemgmt_uri.as_str() {
+                    if url.as_str() != devicemgmt_uri.as_str() {
                         return Err(format!(
                             "advertised device mgmt uri {} not expected {}",
-                            &s.x_addr, &devicemgmt_uri
+                            url.as_str(), &devicemgmt_uri
                         ));
                     }
                 }

--- a/onvif/examples/camera.rs
+++ b/onvif/examples/camera.rs
@@ -111,7 +111,8 @@ impl Clients {
             if !url.as_str().starts_with(base_uri.as_str()) {
                 return Err(format!(
                     "Service URI {} is not within base URI {}",
-                    url.as_str(), &base_uri
+                    url.as_str(),
+                    &base_uri
                 ));
             }
             let svc = Some(
@@ -124,7 +125,8 @@ impl Clients {
                     if url.as_str() != devicemgmt_uri.as_str() {
                         return Err(format!(
                             "advertised device mgmt uri {} not expected {}",
-                            url.as_str(), &devicemgmt_uri
+                            url.as_str(),
+                            &devicemgmt_uri
                         ));
                     }
                 }


### PR DESCRIPTION
Both the parsed url and the device management URL have the port stripped regardless of whether the input arg included one.

s.x_addr provided by the device includes a port on Uniview IPC devices, which leads to failed validation.