### PR TITLE
onvif: Cargo: Update reqwest to use hyper

### DIFF
--- a/onvif/Cargo.toml
+++ b/onvif/Cargo.toml
@@ -6,11 +6,6 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["tls"]
-# hyper-rustls does not support IP hosts (like https://192.168.1.2) which are
-# very common for IP cameras. So we can use only native-tls for now.
-# https://github.com/ctz/hyper-rustls/issues/56
-tls = ["reqwest/native-tls"]
 
 [dependencies]
 async-recursion = "0.3.1"
@@ -21,7 +16,7 @@ chrono = "0.4.19"
 digest_auth = "0.3.0"
 futures-core = "0.3.8"
 num-bigint = "0.4.2"
-reqwest = { version = "0.11.0", default-features = false }
+reqwest = { version = "0.11.20", default-features = false }
 schema = { version = "0.1.0", path = "../schema", default-features = false, features = ["analytics", "devicemgmt", "event", "media", "ptz"] }
 sha1 = "0.6.0"
 thiserror = "1.0"


### PR DESCRIPTION
The issue was fixed on the latest version