### PR TITLE
Add support for the endpoint reference field in WS-Discovery payload

### DIFF
--- a/wsdl_rs/ws_discovery/src/lib.rs
+++ b/wsdl_rs/ws_discovery/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod probe {
-
     use yaserde_derive::YaSerialize;
 
     #[derive(Default, Eq, PartialEq, Debug, YaSerialize)]
@@ -56,8 +55,22 @@ pub mod probe {
     }
 }
 
-pub mod probe_matches {
+pub mod endpoint_reference {
+    use yaserde_derive::YaDeserialize;
 
+    #[derive(Default, Eq, PartialEq, Debug, YaDeserialize)]
+    #[yaserde(
+        prefix = "wsa",
+        namespace = "wsa: http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    )]
+    pub struct EndpointReference {
+        #[yaserde(prefix = "wsa", rename = "Address")]
+        pub address: String,
+    }
+}
+
+pub mod probe_matches {
+    use crate::endpoint_reference::EndpointReference;
     use percent_encoding::percent_decode_str;
     use url::Url;
     use yaserde_derive::YaDeserialize;
@@ -65,9 +78,13 @@ pub mod probe_matches {
     #[derive(Default, Eq, PartialEq, Debug, YaDeserialize)]
     #[yaserde(
         prefix = "d",
-        namespace = "d: http://schemas.xmlsoap.org/ws/2005/04/discovery"
+        namespace = "d: http://schemas.xmlsoap.org/ws/2005/04/discovery",
+        namespace = "wsa: http://schemas.xmlsoap.org/ws/2004/08/addressing"
     )]
     pub struct ProbeMatch {
+        #[yaserde(prefix = "wsa", rename = "EndpointReference")]
+        pub endpoint_reference: EndpointReference,
+
         #[yaserde(prefix = "d", rename = "Types")]
         pub types: String,
 
@@ -141,6 +158,10 @@ pub mod probe_matches {
             self.find_in_scopes("onvif://www.onvif.org/hardware/")
         }
 
+        pub fn endpoint_reference_address(&self) -> String {
+            self.endpoint_reference.address.to_string()
+        }
+
         pub fn find_in_scopes(&self, prefix: &str) -> Option<String> {
             self.scopes().iter().find_map(|url| {
                 url.as_str()
@@ -197,7 +218,7 @@ pub mod probe_matches {
             de.x_addrs(),
             vec![
                 Url::parse("http://192.168.0.100:80/onvif/device_service").unwrap(),
-                Url::parse("http://10.0.0.200:80/onvif/device_service").unwrap()
+                Url::parse("http://10.0.0.200:80/onvif/device_service").unwrap(),
             ]
         );
     }


### PR DESCRIPTION
The endpoint reference is the only reliable way to get a unique identifier of the device without having to authenticate with the device. This is information that is exposed through the WS-Discovery query, but not through the library.

I added the data to the public API.