### PR TITLE
Allow a pre-initalized HTTP client to be passed in the client builder

### DIFF
--- a/onvif/src/soap/auth.rs
+++ b/onvif/src/soap/auth.rs
@@ -1,2 +1,2 @@
-pub(crate) mod digest;
-pub(crate) mod username_token;
+pub mod digest;
+pub mod username_token;

--- a/onvif/src/soap/client.rs
+++ b/onvif/src/soap/client.rs
@@ -39,7 +39,7 @@ pub struct ClientBuilder {
 }
 
 impl ClientBuilder {
-    const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+    pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 
     pub fn new(uri: &Url) -> Self {
         Self {


### PR DESCRIPTION
This PR allows a user to re-use an HTTP client to back a soap client. This can be meaningful when trying limit the amount of outstanding connections taken by each client's connection pool.

I also modified the accessor of the auth module:

```diff
-pub(crate) mod digest;
-pub(crate) mod username_token;
+pub mod digest;
+pub mod username_token;
```

You cleverly allowed the transport to be a generic, so users are free to re-implement their client as they want, but not providing the auth crates mean they have to re-implement everything. This aims to make it a bit more flexible.