### PR TITLE
Add unicast search mode

### DIFF
--- a/onvif/Cargo.toml
+++ b/onvif/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4.19"
 digest_auth = "0.3.0"
 futures = "0.3.30"
 futures-core = "0.3.8"
+futures-util = "0.3.30"
 num-bigint = "0.4.2"
 reqwest = { version = "0.11.20", default-features = false }
 schema = { version = "0.1.0", path = "../schema", default-features = false, features = ["analytics", "devicemgmt", "event", "media", "ptz"] }

--- a/onvif/Cargo.toml
+++ b/onvif/Cargo.toml
@@ -14,6 +14,7 @@ base64 = "0.13.0"
 bigdecimal = "0.3.0"
 chrono = "0.4.19"
 digest_auth = "0.3.0"
+futures = "0.3.30"
 futures-core = "0.3.8"
 num-bigint = "0.4.2"
 reqwest = { version = "0.11.20", default-features = false }

--- a/onvif/src/discovery/mod.rs
+++ b/onvif/src/discovery/mod.rs
@@ -331,7 +331,10 @@ impl DiscoveryBuilder {
             DiscoveryMode::Unicast {
                 network,
                 network_mask,
-            } => self.run_unicast(duration, listen_address, network, network_mask).await,
+            } => {
+                self.run_unicast(duration, listen_address, network, network_mask)
+                    .await
+            }
         }
     }
 }

--- a/onvif/src/discovery/mod.rs
+++ b/onvif/src/discovery/mod.rs
@@ -33,13 +33,20 @@ pub enum Error {
     Unsupported(String),
 }
 
-// TODO
+/// How to discover the devices on the network. Officially, only [DiscoveryMode::Multicast] (the
+/// default) is supported by all onvif devices. However, it is said that sending unicast packets
+/// can work.
 #[derive(Debug, Clone)]
 pub enum DiscoveryMode {
     /// The normal WS-Discovery Mode
     Multicast,
+    /// The unicast approach
     Unicast {
+        /// The network IP address. Must be a valid network address, otherwise the behavior
+        /// will be undefined
         network: Ipv4Addr,
+        /// The network mask, written out in "dotted notation". Must be a valid network mask,
+        /// otherwise the behavior will be undefined.
         network_mask: Ipv4Addr,
     },
 }
@@ -103,6 +110,7 @@ impl DiscoveryBuilder {
     }
 
     /// Set the discovery mode. See [DiscoveryMode] for a description of how this works.
+    /// By default, the multicast mode is chosen.
     pub fn discovery_mode(&mut self, discovery_mode: DiscoveryMode) -> &mut Self {
         self.discovery_mode = discovery_mode;
         self
@@ -314,15 +322,14 @@ impl DiscoveryBuilder {
         } = self;
 
         match discovery_mode {
-            DiscoveryMode::Multicast => self.run_multicast(duration, listen_address).await,
+            DiscoveryMode::Multicast => self.run_multicast(duration, listen_address),
             DiscoveryMode::Unicast {
                 network,
                 network_mask,
             } => {
                 self.run_unicast(duration, listen_address, network, network_mask)
-                    .await
             }
-        }
+        }.await
     }
 }
 

--- a/onvif/src/discovery/mod.rs
+++ b/onvif/src/discovery/mod.rs
@@ -327,13 +327,12 @@ impl DiscoveryBuilder {
         } = self;
 
         match discovery_mode {
-            DiscoveryMode::Multicast => self.run_multicast(duration, listen_address),
+            DiscoveryMode::Multicast => self.run_multicast(duration, listen_address).await,
             DiscoveryMode::Unicast {
                 network,
                 network_mask,
-            } => self.run_unicast(duration, listen_address, network, network_mask),
+            } => self.run_unicast(duration, listen_address, network, network_mask).await,
         }
-        .await
     }
 }
 

--- a/onvif/src/discovery/network_enumeration.rs
+++ b/onvif/src/discovery/network_enumeration.rs
@@ -4,7 +4,7 @@ use std::net::Ipv4Addr;
 fn octets_to_u32(octets: [u8; 4]) -> u32 {
     (octets[0] as u32) << (3 * 8)
         | (octets[1] as u32) << (2 * 8)
-        | (octets[2] as u32) << (1 * 8)
+        | (octets[2] as u32) << 8
         | (octets[3] as u32)
 }
 

--- a/onvif/src/discovery/network_enumeration.rs
+++ b/onvif/src/discovery/network_enumeration.rs
@@ -1,0 +1,54 @@
+use std::net::Ipv4Addr;
+
+#[inline]
+fn octets_to_u32(octets: [u8; 4]) -> u32 {
+    (octets[0] as u32) << (3 * 8)
+        | (octets[1] as u32) << (2 * 8)
+        | (octets[2] as u32) << (1 * 8)
+        | (octets[3] as u32)
+}
+
+/// Enumerate the list of IPs on the network given the network address and the mask.
+pub fn enumerate_network_v4(network: Ipv4Addr, mask: Ipv4Addr) -> Vec<Ipv4Addr> {
+    let network = octets_to_u32(network.octets());
+    let mask = octets_to_u32(mask.octets());
+
+    let mask = !mask;
+
+    let mut ips = Vec::with_capacity(mask as usize);
+
+    for value in 1..mask {
+        let addr = network | value;
+        ips.push(Ipv4Addr::from(addr))
+    }
+
+    ips
+}
+
+/// Tests the enumeration method. See http://jodies.de/ipcalc for examples.
+#[cfg(test)]
+mod test_enumerate_v4 {
+    use super::*;
+
+    #[test]
+    pub fn test_basic_home_network() {
+        let home_net = Ipv4Addr::new(192, 168, 0, 0);
+        let net_mask = Ipv4Addr::new(255, 255, 255, 0);
+
+        let ips = enumerate_network_v4(home_net, net_mask);
+
+        assert_eq!(254, ips.len())
+    }
+
+    #[test]
+    pub fn test_more_complex_net() {
+        let home_net = Ipv4Addr::new(192, 168, 0, 0);
+        let net_mask = Ipv4Addr::new(255, 255, 254, 0);
+
+        let ips = enumerate_network_v4(home_net, net_mask);
+
+        dbg!(&ips);
+
+        assert_eq!(510, ips.len())
+    }
+}


### PR DESCRIPTION
WS Discovery specifies that multicast packets must be sent on the network to find nearby devices. This works fine in most cases, but with the advent of docker networks, some containerized applications cannot send broadcast packets (unless mounted with the `host` network option, which is not always desirable).

This leads to the discovery not working in certain scenarios. While the specification of WS discovery clearly states that the process must be used in broadcast or unicast through a proxy, it was found that sending the probes directly to the devices works in _most_ cases. 

I therefore added the option to the `DiscoveryBuilder` to choose this alternative mode of searching for devices, with a `debug!` warning clearly stating that some devices might be missing. 

The unicasts packets are sent asynchronously. Please double-check my `async` code since this is not a paradigm I often use. The goal is to send all packets and wait for all responses concurrently.