### PR TITLE
add option fix_time_gap to Client and the builder.

### DIFF
--- a/onvif/src/discovery/mod.rs
+++ b/onvif/src/discovery/mod.rs
@@ -481,7 +481,7 @@ mod tests {
         let our_uuid = "uuid:84ede3de-7dec-11d0-c360-F01234567890";
         let bad_uuid = "uuid:84ede3de-7dec-11d0-c360-F00000000000";
 
-        let input = vec![
+        let input = [
             make_xml(our_uuid, "http://addr_20 http://addr_21 http://addr_22"),
             make_xml(bad_uuid, "http://addr_30 http://addr_31"),
         ];

--- a/onvif/src/soap/auth/username_token.rs
+++ b/onvif/src/soap/auth/username_token.rs
@@ -7,10 +7,22 @@ pub struct UsernameToken {
 }
 
 impl UsernameToken {
-    pub fn new(username: &str, password: &str) -> UsernameToken {
+    pub fn new(
+        username: &str,
+        password: &str,
+        fix_time_gap: Option<chrono::Duration>,
+    ) -> UsernameToken {
         let uuid = uuid::Uuid::new_v4();
         let nonce = uuid.as_bytes();
-        let created = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+
+        let mut created = chrono::Utc::now();
+        if let Some(time_gap) = fix_time_gap {
+            created = match created.checked_add_signed(time_gap) {
+                Some(t) => t,
+                None => chrono::Utc::now(),
+            };
+        }
+        let created = created.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
 
         let mut concat = Vec::with_capacity(nonce.len() + created.len() + password.len());
 

--- a/onvif/src/soap/client.rs
+++ b/onvif/src/soap/client.rs
@@ -50,6 +50,7 @@ impl ClientBuilder {
                 response_patcher: None,
                 auth_type: AuthType::Any,
                 timeout: ClientBuilder::DEFAULT_TIMEOUT,
+                fix_time_gap: None,
             },
         }
     }
@@ -76,6 +77,11 @@ impl ClientBuilder {
 
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.config.timeout = timeout;
+        self
+    }
+
+    pub fn fix_time_gap(mut self, time_gap: Option<chrono::Duration>) -> Self {
+        self.config.fix_time_gap = time_gap;
         self
     }
 
@@ -121,6 +127,7 @@ struct Config {
     response_patcher: Option<ResponsePatcher>,
     auth_type: AuthType,
     timeout: Duration,
+    fix_time_gap: Option<chrono::Duration>,
 }
 
 #[derive(Clone, Debug)]
@@ -314,6 +321,10 @@ impl Client {
         self.config
             .credentials
             .as_ref()
-            .map(|c| UsernameToken::new(&c.username, &c.password))
+            .map(|c| UsernameToken::new(&c.username, &c.password, self.config.fix_time_gap))
+    }
+
+    pub fn set_fix_time_gap(&mut self, time_gap: Option<chrono::Duration>) {
+        self.config.fix_time_gap = time_gap;
     }
 }


### PR DESCRIPTION
Solve #121 .
Add option fix_time_gap to Client and the builder.
Update example "camera" to show fix_time_gap usage.