### PR TITLE
update reqwest

### DIFF
--- a/onvif/Cargo.toml
+++ b/onvif/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.30"
 futures-core = "0.3.8"
 futures-util = "0.3.30"
 num-bigint = "0.4.2"
-reqwest = { version = "0.11.20", default-features = false }
+reqwest = { version = "0.12.3", default-features = false }
 schema = { version = "0.1.0", path = "../schema", default-features = false, features = ["analytics", "devicemgmt", "event", "media", "ptz"] }
 sha1 = "0.6.0"
 thiserror = "1.0"


### PR DESCRIPTION
reqwest 0.11 and 0.12 have different types for `reqwest::Client`, to have newer version of reqwest in a project using onvif-rs need to also upgrade reqwest in onvif
