### PR TITLE
Fix for 400 error for Reolink cameras events

### DIFF
--- a/onvif/src/soap/client.rs
+++ b/onvif/src/soap/client.rs
@@ -208,7 +208,7 @@ impl Client {
         debug!(?auth_type, %redirections, "About to make request.");
 
         let soap_msg =
-            soap::soap(message, &username_token).map_err(|e| Error::Protocol(format!("{e:?}")))?;
+            soap::soap(message, &username_token, &uri).map_err(|e| Error::Protocol(format!("{e:?}")))?;
 
         let mut request = self
             .client


### PR DESCRIPTION
I had to make this fix for my Reolink 510a cameras to property talk without getting 400s when subscribing to events. If there is a better way for this change to be made let me know, otherwise hope this helps someone else!