### PR TITLE
Reuse digest auth challenge

### DIFF
--- a/onvif/Cargo.toml
+++ b/onvif/Cargo.toml
@@ -9,36 +9,36 @@ license = "MIT"
 tls = ["reqwest/native-tls"]
 
 [dependencies]
-async-recursion = "0.3.1"
-async-trait = "0.1.41"
-base64 = "0.13.0"
-bigdecimal = "0.3.0"
-chrono = "0.4.19"
-digest_auth = "0.3.0"
-futures = "0.3.30"
-futures-core = "0.3.8"
-futures-util = "0.3.30"
-num-bigint = "0.4.2"
-reqwest = { version = "0.12.3", default-features = false }
+async-recursion = "0.3"
+async-trait = "0.1"
+base64 = "0.13"
+bigdecimal = "0.3"
+chrono = "0.4"
+digest_auth = "0.3"
+futures = "0.3"
+futures-core = "0.3"
+futures-util = "0.3"
+num-bigint = "0.4"
+reqwest = { version = "0.12", default-features = false }
 schema = { version = "0.1.0", path = "../schema", default-features = false, features = ["analytics", "devicemgmt", "event", "media", "ptz"] }
-sha1 = "0.6.0"
+sha1 = "0.6"
 thiserror = "1.0"
 tokio = { version = "1", default-features = false, features = ["net", "sync", "time"] }
 tokio-stream = "0.1"
-tracing = "0.1.26"
-url = "2.2.0"
-uuid = { version = "0.8.1", features = ["v4"] }
-xml-rs = "=0.8.3"
-xmltree = "0.10.2"
+tracing = "0.1"
+url = "2"
+uuid = { version = "1", features = ["v4"] }
+xml-rs = "0.8"
+xmltree = "0.10"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"
 
 [dev-dependencies]
-dotenv = "0.15.0"
-futures-util = "0.3.8"
-structopt = "0.3.21"
-tokio = { version = "1.0.1", features = ["full"] }
-tracing-subscriber = "0.2.20"
+dotenv = "0.15"
+futures-util = "0.3"
+structopt = "0.3"
+tokio = { version = "1", features = ["full"] }
+tracing-subscriber = "0.2"
 b_2 = { path = "../wsdl_rs/b_2" }

--- a/onvif/Cargo.toml
+++ b/onvif/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"
 num-bigint = "0.4"
+nonzero_ext = "0.3"
 reqwest = { version = "0.12", default-features = false }
 schema = { version = "0.1.0", path = "../schema", default-features = false, features = ["analytics", "devicemgmt", "event", "media", "ptz"] }
 sha1 = "0.6"

--- a/onvif/src/soap/tests.rs
+++ b/onvif/src/soap/tests.rs
@@ -11,8 +11,7 @@ fn test_soap() {
         </my:Book>
         "#;
 
-    let expected = r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+    let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
         <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
                     xmlns:my="http://www.example.my/schema">
             <s:Body>
@@ -44,8 +43,7 @@ fn test_unsoap() {
         pub pages: i32,
     }
 
-    let input = r#"
-        <?xml version="1.0" encoding="utf-8"?>
+    let input = r#"<?xml version="1.0" encoding="utf-8"?>
         <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
                     xmlns:my="http://www.example.my/schema">
             <s:Body>
@@ -69,8 +67,7 @@ fn test_unsoap() {
 
 #[test]
 fn test_get_fault() {
-    let response = r#"
-        <?xml version="1.0" ?>
+    let response = r#"<?xml version="1.0" ?>
         <soapenv:Fault
             xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope"
             xmlns:ter="http://www.onvif.org/ver10/error"

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
-bigdecimal = "0.3.0"
-chrono = "0.4.19"
-num-bigint = "0.4.2"
-percent-encoding = "2.1.0"
+bigdecimal = "0.3"
+chrono = "0.4"
+num-bigint = "0.4"
+percent-encoding = "2"
 transport = { path = "../transport" }
-url = "2.2.1"
+url = "2"
 validate = { path = "../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 
@@ -29,40 +29,40 @@ xmlmime = { path = "../xsd_rs/xmlmime" }
 xop = { path = "../xsd_rs/xop" }
 
 # wsdl
-accesscontrol = { path = "../wsdl_rs/accesscontrol" , optional = true}
-accessrules = { path = "../wsdl_rs/accessrules" , optional = true}
-actionengine = { path = "../wsdl_rs/actionengine" , optional = true}
-advancedsecurity = { path = "../wsdl_rs/advancedsecurity" , optional = true}
-analytics = { path = "../wsdl_rs/analytics" , optional = true}
-authenticationbehavior = { path = "../wsdl_rs/authenticationbehavior" , optional = true}
+accesscontrol = { path = "../wsdl_rs/accesscontrol", optional = true }
+accessrules = { path = "../wsdl_rs/accessrules", optional = true }
+actionengine = { path = "../wsdl_rs/actionengine", optional = true }
+advancedsecurity = { path = "../wsdl_rs/advancedsecurity", optional = true }
+analytics = { path = "../wsdl_rs/analytics", optional = true }
+authenticationbehavior = { path = "../wsdl_rs/authenticationbehavior", optional = true }
 b_2 = { path = "../wsdl_rs/b_2" }
-bf_2 = { path = "../wsdl_rs/bf_2" , optional = true}
-credential = { path = "../wsdl_rs/credential" , optional = true}
-deviceio = { path = "../wsdl_rs/deviceio" , optional = true}
-devicemgmt = { path = "../wsdl_rs/devicemgmt" , optional = true}
-display = { path = "../wsdl_rs/display" , optional = true}
-doorcontrol = { path = "../wsdl_rs/doorcontrol" , optional = true}
-event = { path = "../wsdl_rs/event" , optional = true}
-imaging = { path = "../wsdl_rs/imaging" , optional = true}
-media = { path = "../wsdl_rs/media" , optional = true}
-media2 = { path = "../wsdl_rs/media2" , optional = true}
-provisioning = { path = "../wsdl_rs/provisioning" , optional = true}
-ptz = { path = "../wsdl_rs/ptz" , optional = true}
-receiver = { path = "../wsdl_rs/receiver" , optional = true}
-recording = { path = "../wsdl_rs/recording" , optional = true}
-replay = { path = "../wsdl_rs/replay" , optional = true}
-schedule = { path = "../wsdl_rs/schedule" , optional = true}
-search = { path = "../wsdl_rs/search" , optional = true}
+bf_2 = { path = "../wsdl_rs/bf_2", optional = true }
+credential = { path = "../wsdl_rs/credential", optional = true }
+deviceio = { path = "../wsdl_rs/deviceio", optional = true }
+devicemgmt = { path = "../wsdl_rs/devicemgmt", optional = true }
+display = { path = "../wsdl_rs/display", optional = true }
+doorcontrol = { path = "../wsdl_rs/doorcontrol", optional = true }
+event = { path = "../wsdl_rs/event", optional = true }
+imaging = { path = "../wsdl_rs/imaging", optional = true }
+media = { path = "../wsdl_rs/media", optional = true }
+media2 = { path = "../wsdl_rs/media2", optional = true }
+provisioning = { path = "../wsdl_rs/provisioning", optional = true }
+ptz = { path = "../wsdl_rs/ptz", optional = true }
+receiver = { path = "../wsdl_rs/receiver", optional = true }
+recording = { path = "../wsdl_rs/recording", optional = true }
+replay = { path = "../wsdl_rs/replay", optional = true }
+schedule = { path = "../wsdl_rs/schedule", optional = true }
+search = { path = "../wsdl_rs/search", optional = true }
 t_1 = { path = "../wsdl_rs/t_1" }
-thermal = { path = "../wsdl_rs/thermal" , optional = true}
-uplink = { path = "../wsdl_rs/uplink" , optional = true}
+thermal = { path = "../wsdl_rs/thermal", optional = true }
+uplink = { path = "../wsdl_rs/uplink", optional = true }
 ws_addr = { path = "../wsdl_rs/ws_addr" }
 ws_discovery = { path = "../wsdl_rs/ws_discovery" }
 xml_xsd = { path = "../wsdl_rs/xml_xsd" }
 
 [dev-dependencies]
-assert_approx_eq = "1.1.0"
-async-trait = "0.1.42"
-tokio = { version = "1.0.1", features = ["full"] }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+assert_approx_eq = "1"
+async-trait = "0.1"
+tokio = { version = "1", features = ["full"] }
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/schema/src/tests.rs
+++ b/schema/src/tests.rs
@@ -22,8 +22,7 @@ impl transport::Transport for FakeTransport {
 #[test]
 #[cfg(feature = "devicemgmt")]
 fn basic_deserialization() {
-    let response = r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+    let response = r#"<?xml version="1.0" encoding="utf-8"?>
         <tds:GetSystemDateAndTimeResponse
             xmlns:tt="http://www.onvif.org/ver10/schema"
             xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
@@ -70,8 +69,7 @@ fn basic_deserialization() {
 #[cfg(feature = "devicemgmt")]
 #[test]
 fn basic_serialization() {
-    let expected = r#"
-        <?xml version="1.0" encoding="utf-8"?>
+    let expected = r#"<?xml version="1.0" encoding="utf-8"?>
         <tds:GetSystemDateAndTime xmlns:tds="http://www.onvif.org/ver10/device/wsdl" />
         "#;
 
@@ -126,8 +124,7 @@ fn extend_base_serialization() {
         ..Default::default()
     };
 
-    let expected = r#"
-        <?xml version="1.0" encoding="utf-8"?>
+    let expected = r#"<?xml version="1.0" encoding="utf-8"?>
         <tt:VideoSourceConfiguration xmlns:tt="http://www.onvif.org/ver10/schema" token="123abc">
             <tt:SourceToken>456cde</tt:SourceToken>
             <tt:Bounds x="1" y="2" width="3" height="4" />
@@ -256,8 +253,7 @@ fn choice_serialization() {
         ]),
     };
 
-    let expected = r#"
-        <?xml version="1.0" encoding="utf-8"?>
+    let expected = r#"<?xml version="1.0" encoding="utf-8"?>
         <tt:ColorOptions xmlns:tt="http://www.onvif.org/ver10/schema">
             <ColorspaceRange>
                 <tt:X><tt:Min>0.1</tt:Min><tt:Max>0.11</tt:Max></tt:X>
@@ -294,8 +290,7 @@ fn duration_serialization() {
         },
     };
 
-    let expected = r#"
-        <?xml version="1.0" encoding="utf-8"?>
+    let expected = r#"<?xml version="1.0" encoding="utf-8"?>
         <tt:MediaUri xmlns:tt="http://www.onvif.org/ver10/schema">
             <tt:Uri>http://a/b/c</tt:Uri>
             <tt:InvalidAfterConnect>false</tt:InvalidAfterConnect>
@@ -399,8 +394,7 @@ async fn operation_get_device_information() {
 
 #[test]
 fn probe_serialization() {
-    let expected = r#"
-        <?xml version="1.0" encoding="utf-8"?>
+    let expected = r#"<?xml version="1.0" encoding="utf-8"?>
         <s:Envelope
                 xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery"
                 xmlns:s="http://www.w3.org/2003/05/soap-envelope"
@@ -439,8 +433,7 @@ fn probe_match_deserialization() {
     // Following XML was taken from ONVIF guide
     // https://www.onvif.org/wp-content/uploads/2016/12/ONVIF_WG-APG-Application_Programmers_Guide-1.pdf
 
-    let ser = r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+    let ser = r#"<?xml version="1.0" encoding="utf-8"?>
         <SOAP-ENV:Envelope
                     xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope"
                     xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
@@ -510,8 +503,7 @@ fn string_list_serialization() {
         ])),
     };
 
-    let expected = r#"
-        <?xml version="1.0" encoding="utf-8"?>
+    let expected = r#"<?xml version="1.0" encoding="utf-8"?>
         <tt:FocusOptions20Extension xmlns:tt="http://www.onvif.org/ver10/schema">
             <tt:AFModes>Auto Manual</tt:AFModes>
         </tt:FocusOptions20Extension>
@@ -545,8 +537,7 @@ fn string_list_deserialization() {
 fn float_list_serialization() {
     let model = tt::FloatAttrList(vec![1.0, 2.3, 3.99]);
 
-    let expected = r#"
-        <?xml version="1.0" encoding="utf-8"?>
+    let expected = r#"<?xml version="1.0" encoding="utf-8"?>
         <FloatAttrList>1 2.3 3.99</FloatAttrList>
         "#;
 
@@ -557,8 +548,7 @@ fn float_list_serialization() {
 
 #[test]
 fn float_list_deserialization() {
-    let ser = r#"
-        <?xml version="1.0" encoding="utf-8"?>
+    let ser = r#"<?xml version="1.0" encoding="utf-8"?>
         <FloatAttrList>1 2.3 3.99</FloatAttrList>
         "#;
 
@@ -570,8 +560,7 @@ fn float_list_deserialization() {
 #[test]
 fn nested_structs_with_same_named_attributes() {
     // https://github.com/media-io/yaserde/issues/12#issuecomment-601235031
-    let ser = r#"
-        <?xml version="1.0" encoding="utf-8"?>
+    let ser = r#"<?xml version="1.0" encoding="utf-8"?>
         <tt:Profile token="a" xmlns:tt="http://www.onvif.org/ver10/schema">
             <tt:PTZConfiguration token="b" />
         </tt:Profile>
@@ -587,8 +576,7 @@ fn nested_structs_with_same_named_attributes() {
 fn nested_structs_with_same_named_fields() {
     // There was an issue in yaserde which is now fixed
     // https://github.com/media-io/yaserde/issues/51
-    let ser = r#"
-        <?xml version="1.0" encoding="utf-8"?>
+    let ser = r#"<?xml version="1.0" encoding="utf-8"?>
         <tt:Profile xmlns:tt="http://www.onvif.org/ver10/schema">
             <tt:Extension />
         </tt:Profile>
@@ -610,8 +598,7 @@ fn extension_inside_extension() {
     // https://github.com/media-io/yaserde/issues/76
     // If field `extension` in `SecurityCapabilitiesExtension` is uncommented accidentally
     // then this test will fail. Also note that there's a bunch of such cases in `onvif.rs`.
-    let ser = r#"
-    <?xml version="1.0" encoding="utf-8"?>
+    let ser = r#"<?xml version="1.0" encoding="utf-8"?>
     <tt:SecurityCapabilities xmlns:tt="http://www.onvif.org/ver10/schema">
         <tt:Extension>
             <tt:TLS1.0>false</tt:TLS1.0>

--- a/transport/Cargo.toml
+++ b/transport/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-async-trait = "0.1.42"
-thiserror = "1.0.23"
-yaserde = "0.7.1"
+async-trait = "0.1"
+thiserror = "1"
+yaserde = "0.7"

--- a/wsdl_rs/accesscontrol/Cargo.toml
+++ b/wsdl_rs/accesscontrol/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 transport = { path = "../../transport" }
 types = { path = "../../xsd_rs/types" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/accessrules/Cargo.toml
+++ b/wsdl_rs/accessrules/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 transport = { path = "../../transport" }
 types = { path = "../../xsd_rs/types" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/actionengine/Cargo.toml
+++ b/wsdl_rs/actionengine/Cargo.toml
@@ -10,8 +10,8 @@ common = { path = "../../xsd_rs/common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/advancedsecurity/Cargo.toml
+++ b/wsdl_rs/advancedsecurity/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT"
 [dependencies]
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/analytics/Cargo.toml
+++ b/wsdl_rs/analytics/Cargo.toml
@@ -9,8 +9,8 @@ common = { path = "../../xsd_rs/common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/authenticationbehavior/Cargo.toml
+++ b/wsdl_rs/authenticationbehavior/Cargo.toml
@@ -10,8 +10,8 @@ transport = { path = "../../transport" }
 types = { path = "../../xsd_rs/types" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/b_2/Cargo.toml
+++ b/wsdl_rs/b_2/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 t_1 = { path = "../t_1" }
 validate = { path = "../../validate" }
 ws_addr = { path = "../ws_addr" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/bf_2/Cargo.toml
+++ b/wsdl_rs/bf_2/Cargo.toml
@@ -6,10 +6,10 @@ license = "MIT"
 
 [dependencies]
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"
 ws_addr = { path = "../../wsdl_rs/ws_addr" }
 xml_xsd = { path = "../../wsdl_rs/xml_xsd" }

--- a/wsdl_rs/credential/Cargo.toml
+++ b/wsdl_rs/credential/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 transport = { path = "../../transport" }
 types = { path = "../../xsd_rs/types" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/deviceio/Cargo.toml
+++ b/wsdl_rs/deviceio/Cargo.toml
@@ -10,8 +10,8 @@ devicemgmt = { path = "../../wsdl_rs/devicemgmt" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/devicemgmt/Cargo.toml
+++ b/wsdl_rs/devicemgmt/Cargo.toml
@@ -9,8 +9,8 @@ common = { path = "../../xsd_rs/common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/display/Cargo.toml
+++ b/wsdl_rs/display/Cargo.toml
@@ -9,8 +9,8 @@ common = { path = "../../xsd_rs/common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/doorcontrol/Cargo.toml
+++ b/wsdl_rs/doorcontrol/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 transport = { path = "../../transport" }
 types = { path = "../../xsd_rs/types" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/event/Cargo.toml
+++ b/wsdl_rs/event/Cargo.toml
@@ -9,9 +9,9 @@ b_2 = { path = "../../wsdl_rs/b_2" }
 t_1 = { path = "../../wsdl_rs/t_1" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"
 ws_addr = { path = "../../wsdl_rs/ws_addr" }

--- a/wsdl_rs/imaging/Cargo.toml
+++ b/wsdl_rs/imaging/Cargo.toml
@@ -9,8 +9,8 @@ common = { path = "../../xsd_rs/common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/media/Cargo.toml
+++ b/wsdl_rs/media/Cargo.toml
@@ -9,8 +9,8 @@ common = { path = "../../xsd_rs/common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/media2/Cargo.toml
+++ b/wsdl_rs/media2/Cargo.toml
@@ -9,8 +9,8 @@ common = { path = "../../xsd_rs/common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/provisioning/Cargo.toml
+++ b/wsdl_rs/provisioning/Cargo.toml
@@ -9,8 +9,8 @@ common = { path = "../../xsd_rs/common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/ptz/Cargo.toml
+++ b/wsdl_rs/ptz/Cargo.toml
@@ -9,8 +9,8 @@ common = { path = "../../xsd_rs/common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/receiver/Cargo.toml
+++ b/wsdl_rs/receiver/Cargo.toml
@@ -9,8 +9,8 @@ common = { path = "../../xsd_rs/common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/recording/Cargo.toml
+++ b/wsdl_rs/recording/Cargo.toml
@@ -9,8 +9,8 @@ common = { path = "../../xsd_rs/common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/replay/Cargo.toml
+++ b/wsdl_rs/replay/Cargo.toml
@@ -9,8 +9,8 @@ common = { path = "../../xsd_rs/common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/schedule/Cargo.toml
+++ b/wsdl_rs/schedule/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 transport = { path = "../../transport" }
 types = { path = "../../xsd_rs/types" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/search/Cargo.toml
+++ b/wsdl_rs/search/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/t_1/Cargo.toml
+++ b/wsdl_rs/t_1/Cargo.toml
@@ -6,8 +6,8 @@ license = "MIT"
 
 [dependencies]
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/thermal/Cargo.toml
+++ b/wsdl_rs/thermal/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/uplink/Cargo.toml
+++ b/wsdl_rs/uplink/Cargo.toml
@@ -7,6 +7,6 @@ license = "MIT"
 [dependencies]
 transport = { path = "../../transport" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+xml-rs = "0.8"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/ws_addr/Cargo.toml
+++ b/wsdl_rs/ws_addr/Cargo.toml
@@ -6,8 +6,8 @@ license = "MIT"
 
 [dependencies]
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/ws_discovery/Cargo.toml
+++ b/wsdl_rs/ws_discovery/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-percent-encoding = "2.1.0"
-url = "2.2.1"
-xml-rs = "=0.8.3"
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+percent-encoding = "2"
+url = "2"
+xml-rs = "0.8"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/wsdl_rs/ws_discovery/src/lib.rs
+++ b/wsdl_rs/ws_discovery/src/lib.rs
@@ -188,8 +188,7 @@ pub mod probe_matches {
 
     #[test]
     fn probe_match() {
-        let ser = r#"
-        <?xml version="1.0" encoding="utf-8"?>
+        let ser = r#"<?xml version="1.0" encoding="utf-8"?>
         <wsd:ProbeMatch xmlns:wsd="http://schemas.xmlsoap.org/ws/2005/04/discovery"
                         xmlns:dn="http://www.onvif.org/ver10/network/wsdl"
                         xmlns:tds="http://www.onvif.org/ver10/device/wsdl">

--- a/wsdl_rs/xml_xsd/Cargo.toml
+++ b/wsdl_rs/xml_xsd/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-xml-rs = "=0.8.3"
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+xml-rs = "0.8"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/xsd_rs/common/Cargo.toml
+++ b/xsd_rs/common/Cargo.toml
@@ -6,8 +6,8 @@ license = "MIT"
 
 [dependencies]
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/xsd_rs/metadatastream/Cargo.toml
+++ b/xsd_rs/metadatastream/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 b_2 = { path = "../../wsdl_rs/b_2" }
 common = { path = "../common" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/xsd_rs/onvif_xsd/Cargo.toml
+++ b/xsd_rs/onvif_xsd/Cargo.toml
@@ -9,10 +9,10 @@ b_2 = { path = "../../wsdl_rs/b_2" }
 common = { path = "../common" }
 soap_envelope = { path = "../../xsd_rs/soap_envelope" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xmlmime = { path = "../../xsd_rs/xmlmime" }
 xop = { path = "../../xsd_rs/xop" }
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/xsd_rs/radiometry/Cargo.toml
+++ b/xsd_rs/radiometry/Cargo.toml
@@ -10,10 +10,10 @@ common = { path = "../common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 soap_envelope = { path = "../../xsd_rs/soap_envelope" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xmlmime = { path = "../../xsd_rs/xmlmime" }
 xop = { path = "../../xsd_rs/xop" }
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/xsd_rs/rules/Cargo.toml
+++ b/xsd_rs/rules/Cargo.toml
@@ -10,10 +10,10 @@ common = { path = "../common" }
 onvif = { package = "onvif-xsd", path = "../../xsd_rs/onvif_xsd" }
 soap_envelope = { path = "../../xsd_rs/soap_envelope" }
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xmlmime = { path = "../../xsd_rs/xmlmime" }
 xop = { path = "../../xsd_rs/xop" }
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/xsd_rs/soap_envelope/Cargo.toml
+++ b/xsd_rs/soap_envelope/Cargo.toml
@@ -6,8 +6,8 @@ license = "MIT"
 
 [dependencies]
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/xsd_rs/types/Cargo.toml
+++ b/xsd_rs/types/Cargo.toml
@@ -6,8 +6,8 @@ license = "MIT"
 
 [dependencies]
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/xsd_rs/xmlmime/Cargo.toml
+++ b/xsd_rs/xmlmime/Cargo.toml
@@ -6,8 +6,8 @@ license = "MIT"
 
 [dependencies]
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
+xml-rs = "0.8"
 xsd-macro-utils = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
 xsd-types = { git = "https://github.com/lumeohq/xsd-parser-rs", rev = "7f3d433" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.7"
+yaserde_derive = "0.7"

--- a/xsd_rs/xop/Cargo.toml
+++ b/xsd_rs/xop/Cargo.toml
@@ -6,6 +6,6 @@ license = "MIT"
 
 [dependencies]
 validate = { path = "../../validate" }
-xml-rs = "=0.8.3"
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+xml-rs = "0.8"
+yaserde = "0.7"
+yaserde_derive = "0.7"


### PR DESCRIPTION
Digest auth works this way:
- First we get a 401 with challenge, from which we calculate auth header for the next request
- Next we get 200 with the actual response.

The problem here is that for multiple requests to the same service (let's say to media service `http://192.168.0.128/onvif/Media`), we perform an extra request to obtain a new challenge. However, we can reuse the challenge from the very first 401 and receive 200's in following requests immediately. This challenge gets stale at some point, though, so I handled this as well in this PR.

Before:

```
2024-10-11T11:59:54.728210Z DEBUG onvif::soap::client: http://192.168.0.128/onvif/Media: Response status: 401 Unauthorized
2024-10-11T11:59:54.763040Z DEBUG onvif::soap::client: http://192.168.0.128/onvif/Media: Response status: 200 OK
2024-10-11T11:59:54.788537Z DEBUG onvif::soap::client: http://192.168.0.128/onvif/Media: Response status: 401 Unauthorized
2024-10-11T11:59:54.832126Z DEBUG onvif::soap::client: http://192.168.0.128/onvif/Media: Response status: 200 OK
2024-10-11T11:59:54.860021Z DEBUG onvif::soap::client: http://192.168.0.128/onvif/Media: Response status: 401 Unauthorized
2024-10-11T11:59:54.892962Z DEBUG onvif::soap::client: http://192.168.0.128/onvif/Media: Response status: 200 OK
2024-10-11T11:59:54.919252Z DEBUG onvif::soap::client: http://192.168.0.128/onvif/Media: Response status: 401 Unauthorized
2024-10-11T11:59:54.953114Z DEBUG onvif::soap::client: http://192.168.0.128/onvif/Media: Response status: 200 OK
```

After:
```
2024-10-11T11:42:00.963856Z DEBUG request{uri="http://192.168.0.128/onvif/Media"}: onvif::soap::client: Response status: 401 Unauthorized
2024-10-11T11:42:00.995125Z DEBUG request{uri="http://192.168.0.128/onvif/Media"}: onvif::soap::client: Response status: 200 OK
2024-10-11T11:42:01.058180Z DEBUG request{uri="http://192.168.0.128/onvif/Media"}: onvif::soap::client: Response status: 200 OK
2024-10-11T11:42:01.098189Z DEBUG request{uri="http://192.168.0.128/onvif/Media"}: onvif::soap::client: Response status: 200 OK
2024-10-11T11:42:01.138092Z DEBUG request{uri="http://192.168.0.128/onvif/Media"}: onvif::soap::client: Response status: 200 OK
2024-10-11T11:42:01.178275Z DEBUG request{uri="http://192.168.0.128/onvif/Media"}: onvif::soap::client: Response status: 200 OK
... a minute later nonce gets too old, so we get a new challenge and continue working
2024-10-11T11:43:00.994051Z DEBUG request{uri="http://192.168.0.128/onvif/Media"}: onvif::soap::client: Response status: 401 Unauthorized
2024-10-11T11:43:01.027800Z DEBUG request{uri="http://192.168.0.128/onvif/Media"}: onvif::soap::client: Response status: 200 OK
2024-10-11T11:43:01.068052Z DEBUG request{uri="http://192.168.0.128/onvif/Media"}: onvif::soap::client: Response status: 200 OK
2024-10-11T11:43:01.108224Z DEBUG request{uri="http://192.168.0.128/onvif/Media"}: onvif::soap::client: Response status: 200 OK
...
```

For context: we need this for VMSes which tend to have hundreds of cameras connected, and we have to do `GetStreamUri` in a separate request for each camera. ONVIF doesn't have bulk requests, so per-request optimizations now make some sense.