### PR TITLE
Disable re-using digest auth headers by default

### DIFF
--- a/onvif/src/soap/client.rs
+++ b/onvif/src/soap/client.rs
@@ -41,6 +41,7 @@ impl ClientBuilder {
                 credentials: None,
                 response_patcher: None,
                 auth_type: AuthType::Any,
+                reuse_digest_auth_headers: false,
                 timeout: ClientBuilder::DEFAULT_TIMEOUT,
                 fix_time_gap: None,
             },
@@ -67,6 +68,11 @@ impl ClientBuilder {
         self
     }
 
+    pub fn reuse_digest_auth_headers(mut self, reuse_digest_auth_headers: bool) -> Self {
+        self.config.reuse_digest_auth_headers = reuse_digest_auth_headers;
+        self
+    }
+
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.config.timeout = timeout;
         self
@@ -87,7 +93,11 @@ impl ClientBuilder {
                 .unwrap()
         };
 
-        let digest = Digest::new(&self.config.uri, &self.config.credentials);
+        let digest = Digest::new(
+            &self.config.uri,
+            &self.config.credentials,
+            self.config.reuse_digest_auth_headers,
+        );
 
         Client {
             client,
@@ -121,6 +131,7 @@ struct Config {
     credentials: Option<Credentials>,
     response_patcher: Option<ResponsePatcher>,
     auth_type: AuthType,
+    reuse_digest_auth_headers: bool,
     timeout: Duration,
     fix_time_gap: Option<chrono::Duration>,
 }

--- a/schema/src/tests/utils.rs
+++ b/schema/src/tests/utils.rs
@@ -1,6 +1,26 @@
+use xml::reader::XmlEvent;
+
 pub fn assert_xml_eq(actual: &str, expected: &str) {
     for (a, e) in without_whitespaces(actual).zip(without_whitespaces(expected)) {
-        assert_eq!(a, e);
+        match (a, e) {
+            (
+                Ok(XmlEvent::StartDocument {
+                    version,
+                    encoding,
+                    standalone,
+                }),
+                Ok(XmlEvent::StartDocument {
+                    version: version_expected,
+                    encoding: encoding_expected,
+                    standalone: standalone_expected,
+                }),
+            ) => {
+                assert_eq!(version, version_expected);
+                assert_eq!(encoding.to_lowercase(), encoding_expected.to_lowercase());
+                assert_eq!(standalone, standalone_expected);
+            }
+            (a, e) => assert_eq!(a, e),
+        }
     }
 }
 


### PR DESCRIPTION
One of our VMSes doesn't work well when headers are reused.